### PR TITLE
Add technical GEO foundation

### DIFF
--- a/FAQ.html
+++ b/FAQ.html
@@ -2,8 +2,8 @@
 layout: default-shared
 title: "Frequently Asked Questions | Bluedobie Developing"
 description: "Answers about Bluedobie Developing's website help, free web audits, DobieCore Suite content support, and the upcoming Bifrost business continuity system."
-og_image: "https://bluedobiedev.com/images/confused-sabre.webp"
-canonical: "https://www.bluedobiedev.com/FAQ"
+og_image: "https://www.bluedobiedev.com/images/confused-sabre.webp"
+canonical_url: "https://www.bluedobiedev.com/FAQ.html"
 permalink: /FAQ.html
 extra_css: /css/faq.css
 extra_scripts: |
@@ -113,4 +113,3 @@ extra_scripts: |
     </div>
   </div>
 </div>
-

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,21 @@
 title: "Bluedobie Developing"
+description: "Bluedobie Developing helps small businesses reduce website and content overwhelm with practical websites, free website audits, DobieCore content systems, and AI-supported workflow tools."
 url: "https://www.bluedobiedev.com"
 baseurl: ""   # leave empty at domain root
 repository: "sabrebluedobie/sabrebluedobie.github.io"
+author: "Melanie Brown"
+logo: "/images/bluedobielogo_1.webp"
+email: "melanie.brown@bluedobiedev.com"
+phone: "270-388-3535"
+location: "Princeton, Kentucky"
+service_area: "Western Kentucky"
+consult_url: "/contact.html"
+
+social:
+  facebook: "https://facebook.com/bluedobiedev"
+  instagram: "https://instagram.com/bluedobiedev"
+  linkedin: "https://linkedin.com/company/bluedobie-developing"
+  github: "https://github.com/sabrebluedobie"
 
 # Blog posts (Bluedobie Dialogues)
 collections:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,8 +4,8 @@
 <meta name="cf-rocket-loader" content="off">
 {%- assign _title   = page.title | default: site.title | default: "Bluedobie Developing" -%}
 {%- assign _desc    = page.description | default: page.excerpt | default: page.content | strip_html | normalize_whitespace | truncate: 160 -%}
-{%- assign _image   = page.image | default: "/assets/images/bluedobielogo_1.webp" | absolute_url -%}
-{%- assign _canon   = page.canonical_url | default: page.url | absolute_url -%}
+{%- assign _image   = page.og_image | default: page.image | default: "/assets/images/bluedobielogo_1.webp" | absolute_url -%}
+{%- assign _canon   = page.canonical_url | default: page.canonical | default: page.url | absolute_url -%}
 {%- assign _og_type = page.og_type | default: (page.layout == "post" or page.collection == "posts") | ternary: "article", "website" -%}
 
 <title>{{ _title }}</title>
@@ -13,6 +13,7 @@
 <link rel="canonical" href="{{ _canon }}">
 
 <!-- Open Graph -->
+<meta property="og:site_name" content="Bluedobie Developing">
 <meta property="og:title" content="{{ _title }}">
 {%- if _desc and _desc != "" -%}<meta property="og:description" content="{{ _desc }}">{%- endif -%}
 <meta property="og:type" content="{{ _og_type }}">
@@ -24,6 +25,9 @@
 <meta name="twitter:title" content="{{ _title }}">
 {%- if _desc and _desc != "" -%}<meta name="twitter:description" content="{{ _desc }}">{%- endif -%}
 <meta name="twitter:image" content="{{ _image }}">
+
+<!-- GEO / Structured Data -->
+{% include schema-jsonld.html %}
 
 <!-- Fonts -->
 <link rel="preload"

--- a/_includes/schema-jsonld.html
+++ b/_includes/schema-jsonld.html
@@ -52,7 +52,31 @@
         "business continuity planning",
         "DobieCore Suite",
         "Bifrost"
-      ]
+      ],
+      "hasOfferCatalog": {
+        "@type": "OfferCatalog",
+        "name": "Bluedobie Developing services and products",
+        "itemListElement": [
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@id": "{{ '/services.html' | absolute_url }}#service"
+            }
+          },
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@id": "{{ '/free-web-audit/' | absolute_url }}#service"
+            }
+          },
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@id": "{{ '/dobiecore/' | absolute_url }}#dobiecore-suite"
+            }
+          }
+        ]
+      }
     },
     {
       "@type": "Person",
@@ -193,6 +217,45 @@
     "price": "0",
     "priceCurrency": "USD",
     "description": "Free sign-up with paid usage after free limits."
+  }
+}
+</script>
+{%- endif -%}
+
+{%- if page.url == '/looking-ahead/' -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  "@id": "{{ schema_url }}#bifrost",
+  "name": "Bifrost",
+  "url": "{{ schema_url }}",
+  "description": "Bifrost is a developing local-first concept from Bluedobie Developing for AI workflow routing and small business continuity planning.",
+  "creator": {
+    "@id": "{{ '/' | absolute_url }}#organization"
+  },
+  "keywords": [
+    "AI workflow routing",
+    "small business continuity planning",
+    "business owner absence support",
+    "local-first AI systems"
+  ]
+}
+</script>
+{%- endif -%}
+
+{%- if page.url == '/meet-sabre.html' -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Thing",
+  "@id": "{{ schema_url }}#sabre",
+  "name": "Sabre",
+  "url": "{{ schema_url }}",
+  "description": "Sabre is Melanie Brown's blue Doberman and part of the Bluedobie Developing brand story.",
+  "image": "{{ '/images/sabresmile-p-1080.webp' | absolute_url }}",
+  "subjectOf": {
+    "@id": "{{ schema_url }}#webpage"
   }
 }
 </script>

--- a/_includes/schema-jsonld.html
+++ b/_includes/schema-jsonld.html
@@ -1,11 +1,12 @@
 {%- comment -%}
   GEO / structured data foundation for Bluedobie Developing.
   Kept in one include so every page can share the same entity graph.
+  Use jsonify for dynamic strings so rendered JSON-LD remains valid.
 {%- endcomment -%}
 {%- assign schema_title = page.title | default: site.title | default: 'Bluedobie Developing' -%}
 {%- assign schema_desc = page.description | default: page.excerpt | default: site.description | default: 'Bluedobie Developing helps small businesses with practical websites, content systems, free website audits, and AI-supported workflows.' | strip_html | normalize_whitespace -%}
 {%- assign schema_url = page.canonical_url | default: page.canonical | default: page.url | absolute_url -%}
-{%- assign schema_image = page.og_image | default: page.image | default: '/assets/images/bluedobielogo_1.webp' | absolute_url -%}
+{%- assign schema_image = page.og_image | default: page.image | default: site.logo | default: '/assets/images/bluedobielogo_1.webp' | absolute_url -%}
 
 <script type="application/ld+json">
 {
@@ -13,15 +14,15 @@
   "@graph": [
     {
       "@type": ["ProfessionalService", "LocalBusiness"],
-      "@id": "{{ '/' | absolute_url }}#organization",
+      "@id": {{ '/' | absolute_url | append: '#organization' | jsonify }},
       "name": "Bluedobie Developing",
       "legalName": "Bluedobie Developing, LLC",
-      "url": "{{ '/' | absolute_url }}",
-      "logo": "{{ '/images/bluedobielogo_1.webp' | absolute_url }}",
-      "image": "{{ schema_image }}",
+      "url": {{ '/' | absolute_url | jsonify }},
+      "logo": {{ '/images/bluedobielogo_1.webp' | absolute_url | jsonify }},
+      "image": {{ '/images/bluedobielogo_1.webp' | absolute_url | jsonify }},
       "description": "Founder-led small business web design, website cleanup, free website audits, content systems, and practical AI workflow support from Princeton, Kentucky.",
       "founder": {
-        "@id": "{{ '/about.html' | absolute_url }}#melanie-brown"
+        "@id": {{ '/about.html' | absolute_url | append: '#melanie-brown' | jsonify }}
       },
       "areaServed": [
         { "@type": "Place", "name": "Western Kentucky" },
@@ -60,19 +61,19 @@
           {
             "@type": "Offer",
             "itemOffered": {
-              "@id": "{{ '/services.html' | absolute_url }}#service"
+              "@id": {{ '/services.html' | absolute_url | append: '#service' | jsonify }}
             }
           },
           {
             "@type": "Offer",
             "itemOffered": {
-              "@id": "{{ '/free-web-audit/' | absolute_url }}#service"
+              "@id": {{ '/free-web-audit/' | absolute_url | append: '#service' | jsonify }}
             }
           },
           {
             "@type": "Offer",
             "itemOffered": {
-              "@id": "{{ '/dobiecore/' | absolute_url }}#dobiecore-suite"
+              "@id": {{ '/dobiecore/' | absolute_url | append: '#dobiecore-suite' | jsonify }}
             }
           }
         ]
@@ -80,13 +81,13 @@
     },
     {
       "@type": "Person",
-      "@id": "{{ '/about.html' | absolute_url }}#melanie-brown",
+      "@id": {{ '/about.html' | absolute_url | append: '#melanie-brown' | jsonify }},
       "name": "Melanie Brown",
-      "url": "{{ '/about.html' | absolute_url }}",
-      "image": "{{ '/images/Melanieheadshot.webp' | absolute_url }}",
+      "url": {{ '/about.html' | absolute_url | jsonify }},
+      "image": {{ '/images/Melanieheadshot.webp' | absolute_url | jsonify }},
       "jobTitle": "Founder and Web Designer",
       "worksFor": {
-        "@id": "{{ '/' | absolute_url }}#organization"
+        "@id": {{ '/' | absolute_url | append: '#organization' | jsonify }}
       },
       "knowsAbout": [
         "web design",
@@ -98,47 +99,47 @@
     },
     {
       "@type": "WebSite",
-      "@id": "{{ '/' | absolute_url }}#website",
+      "@id": {{ '/' | absolute_url | append: '#website' | jsonify }},
       "name": "Bluedobie Developing",
-      "url": "{{ '/' | absolute_url }}",
+      "url": {{ '/' | absolute_url | jsonify }},
       "publisher": {
-        "@id": "{{ '/' | absolute_url }}#organization"
+        "@id": {{ '/' | absolute_url | append: '#organization' | jsonify }}
       },
       "inLanguage": "en-US"
     },
     {
       "@type": "WebPage",
-      "@id": "{{ schema_url }}#webpage",
-      "url": "{{ schema_url }}",
-      "name": "{{ schema_title | escape }}",
-      "description": "{{ schema_desc | escape }}",
+      "@id": {{ schema_url | append: '#webpage' | jsonify }},
+      "url": {{ schema_url | jsonify }},
+      "name": {{ schema_title | jsonify }},
+      "description": {{ schema_desc | jsonify }},
       "isPartOf": {
-        "@id": "{{ '/' | absolute_url }}#website"
+        "@id": {{ '/' | absolute_url | append: '#website' | jsonify }}
       },
       "about": {
-        "@id": "{{ '/' | absolute_url }}#organization"
+        "@id": {{ '/' | absolute_url | append: '#organization' | jsonify }}
       },
       "primaryImageOfPage": {
         "@type": "ImageObject",
-        "url": "{{ schema_image }}"
+        "url": {{ schema_image | jsonify }}
       },
       "inLanguage": "en-US"
     },
     {
       "@type": "BreadcrumbList",
-      "@id": "{{ schema_url }}#breadcrumb",
+      "@id": {{ schema_url | append: '#breadcrumb' | jsonify }},
       "itemListElement": [
         {
           "@type": "ListItem",
           "position": 1,
           "name": "Home",
-          "item": "{{ '/' | absolute_url }}"
+          "item": {{ '/' | absolute_url | jsonify }}
         }{% unless page.url == '/' %},
         {
           "@type": "ListItem",
           "position": 2,
-          "name": "{{ schema_title | escape }}",
-          "item": "{{ schema_url }}"
+          "name": {{ schema_title | jsonify }},
+          "item": {{ schema_url | jsonify }}
         }{% endunless %}
       ]
     }
@@ -151,7 +152,7 @@
 {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  "@id": "{{ schema_url }}#faq",
+  "@id": {{ schema_url | append: '#faq' | jsonify }},
   "mainEntity": [
     {
       "@type": "Question",
@@ -203,14 +204,14 @@
 {
   "@context": "https://schema.org",
   "@type": "WebApplication",
-  "@id": "{{ schema_url }}#dobiecore-suite",
+  "@id": {{ schema_url | append: '#dobiecore-suite' | jsonify }},
   "name": "DobieCore Suite",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Web",
-  "url": "{{ schema_url }}",
+  "url": {{ schema_url | jsonify }},
   "description": "Brand voice-based content support for small businesses, including prewriting, captions, image direction, blog drafts, and content calendar templates.",
   "creator": {
-    "@id": "{{ '/' | absolute_url }}#organization"
+    "@id": {{ '/' | absolute_url | append: '#organization' | jsonify }}
   },
   "offers": {
     "@type": "Offer",
@@ -227,12 +228,12 @@
 {
   "@context": "https://schema.org",
   "@type": "CreativeWork",
-  "@id": "{{ schema_url }}#bifrost",
+  "@id": {{ schema_url | append: '#bifrost' | jsonify }},
   "name": "Bifrost",
-  "url": "{{ schema_url }}",
+  "url": {{ schema_url | jsonify }},
   "description": "Bifrost is a developing local-first concept from Bluedobie Developing for AI workflow routing and small business continuity planning.",
   "creator": {
-    "@id": "{{ '/' | absolute_url }}#organization"
+    "@id": {{ '/' | absolute_url | append: '#organization' | jsonify }}
   },
   "keywords": [
     "AI workflow routing",
@@ -249,13 +250,13 @@
 {
   "@context": "https://schema.org",
   "@type": "Thing",
-  "@id": "{{ schema_url }}#sabre",
+  "@id": {{ schema_url | append: '#sabre' | jsonify }},
   "name": "Sabre",
-  "url": "{{ schema_url }}",
+  "url": {{ schema_url | jsonify }},
   "description": "Sabre is Melanie Brown's blue Doberman and part of the Bluedobie Developing brand story.",
-  "image": "{{ '/images/sabresmile-p-1080.webp' | absolute_url }}",
+  "image": {{ '/images/sabresmile-p-1080.webp' | absolute_url | jsonify }},
   "subjectOf": {
-    "@id": "{{ schema_url }}#webpage"
+    "@id": {{ schema_url | append: '#webpage' | jsonify }}
   }
 }
 </script>
@@ -266,12 +267,12 @@
 {
   "@context": "https://schema.org",
   "@type": "Service",
-  "@id": "{{ schema_url }}#service",
-  "name": "{{ schema_title | escape }}",
-  "url": "{{ schema_url }}",
-  "description": "{{ schema_desc | escape }}",
+  "@id": {{ schema_url | append: '#service' | jsonify }},
+  "name": {{ schema_title | jsonify }},
+  "url": {{ schema_url | jsonify }},
+  "description": {{ schema_desc | jsonify }},
   "provider": {
-    "@id": "{{ '/' | absolute_url }}#organization"
+    "@id": {{ '/' | absolute_url | append: '#organization' | jsonify }}
   },
   "areaServed": [
     "Western Kentucky",

--- a/_includes/schema-jsonld.html
+++ b/_includes/schema-jsonld.html
@@ -1,0 +1,221 @@
+{%- comment -%}
+  GEO / structured data foundation for Bluedobie Developing.
+  Kept in one include so every page can share the same entity graph.
+{%- endcomment -%}
+{%- assign schema_title = page.title | default: site.title | default: 'Bluedobie Developing' -%}
+{%- assign schema_desc = page.description | default: page.excerpt | default: site.description | default: 'Bluedobie Developing helps small businesses with practical websites, content systems, free website audits, and AI-supported workflows.' | strip_html | normalize_whitespace -%}
+{%- assign schema_url = page.canonical_url | default: page.canonical | default: page.url | absolute_url -%}
+{%- assign schema_image = page.og_image | default: page.image | default: '/assets/images/bluedobielogo_1.webp' | absolute_url -%}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": ["ProfessionalService", "LocalBusiness"],
+      "@id": "{{ '/' | absolute_url }}#organization",
+      "name": "Bluedobie Developing",
+      "legalName": "Bluedobie Developing, LLC",
+      "url": "{{ '/' | absolute_url }}",
+      "logo": "{{ '/images/bluedobielogo_1.webp' | absolute_url }}",
+      "image": "{{ schema_image }}",
+      "description": "Founder-led small business web design, website cleanup, free website audits, content systems, and practical AI workflow support from Princeton, Kentucky.",
+      "founder": {
+        "@id": "{{ '/about.html' | absolute_url }}#melanie-brown"
+      },
+      "areaServed": [
+        { "@type": "Place", "name": "Western Kentucky" },
+        { "@type": "AdministrativeArea", "name": "Kentucky" },
+        { "@type": "Country", "name": "United States" }
+      ],
+      "telephone": "+1-270-388-3535",
+      "email": "melanie.brown@bluedobiedev.com",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Princeton",
+        "addressRegion": "KY",
+        "addressCountry": "US"
+      },
+      "sameAs": [
+        "https://facebook.com/bluedobiedev",
+        "https://instagram.com/bluedobiedev",
+        "https://linkedin.com/company/bluedobie-developing",
+        "https://github.com/sabrebluedobie"
+      ],
+      "knowsAbout": [
+        "small business web design",
+        "website audits",
+        "local SEO basics",
+        "content systems",
+        "brand voice",
+        "AI workflow routing",
+        "business continuity planning",
+        "DobieCore Suite",
+        "Bifrost"
+      ]
+    },
+    {
+      "@type": "Person",
+      "@id": "{{ '/about.html' | absolute_url }}#melanie-brown",
+      "name": "Melanie Brown",
+      "url": "{{ '/about.html' | absolute_url }}",
+      "image": "{{ '/images/Melanieheadshot.webp' | absolute_url }}",
+      "jobTitle": "Founder and Web Designer",
+      "worksFor": {
+        "@id": "{{ '/' | absolute_url }}#organization"
+      },
+      "knowsAbout": [
+        "web design",
+        "small business websites",
+        "content systems",
+        "practical AI workflows",
+        "brand voice tools"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "{{ '/' | absolute_url }}#website",
+      "name": "Bluedobie Developing",
+      "url": "{{ '/' | absolute_url }}",
+      "publisher": {
+        "@id": "{{ '/' | absolute_url }}#organization"
+      },
+      "inLanguage": "en-US"
+    },
+    {
+      "@type": "WebPage",
+      "@id": "{{ schema_url }}#webpage",
+      "url": "{{ schema_url }}",
+      "name": "{{ schema_title | escape }}",
+      "description": "{{ schema_desc | escape }}",
+      "isPartOf": {
+        "@id": "{{ '/' | absolute_url }}#website"
+      },
+      "about": {
+        "@id": "{{ '/' | absolute_url }}#organization"
+      },
+      "primaryImageOfPage": {
+        "@type": "ImageObject",
+        "url": "{{ schema_image }}"
+      },
+      "inLanguage": "en-US"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "{{ schema_url }}#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "{{ '/' | absolute_url }}"
+        }{% unless page.url == '/' %},
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "{{ schema_title | escape }}",
+          "item": "{{ schema_url }}"
+        }{% endunless %}
+      ]
+    }
+  ]
+}
+</script>
+
+{%- if page.url == '/FAQ.html' -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "@id": "{{ schema_url }}#faq",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is Bluedobie Developing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Bluedobie Developing is a small business web design and content systems company founded by Melanie Brown. Bluedobie builds practical websites and free web audits locally in Western Kentucky, and supports small businesses nationally through DobieCore Suite."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Who is Melanie Brown?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Melanie Brown is the founder of Bluedobie Developing. She is based in Princeton, Kentucky, and builds practical digital systems for small businesses."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What website services does Bluedobie Developing offer?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Bluedobie Developing offers basic small business websites, light website edits and updates, website cleanup, and free website audits."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is DobieCore Suite?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "DobieCore Suite is a brand voice-based content system that helps small businesses with prewriting, captions, images, blogs, and a content calendar template."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is Bifrost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Bifrost is a developing concept for AI workflow routing and small business continuity planning, including support for unexpected owner absence."
+      }
+    }
+  ]
+}
+</script>
+{%- endif -%}
+
+{%- if page.url == '/dobiecore/' -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "@id": "{{ schema_url }}#dobiecore-suite",
+  "name": "DobieCore Suite",
+  "applicationCategory": "BusinessApplication",
+  "operatingSystem": "Web",
+  "url": "{{ schema_url }}",
+  "description": "Brand voice-based content support for small businesses, including prewriting, captions, image direction, blog drafts, and content calendar templates.",
+  "creator": {
+    "@id": "{{ '/' | absolute_url }}#organization"
+  },
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD",
+    "description": "Free sign-up with paid usage after free limits."
+  }
+}
+</script>
+{%- endif -%}
+
+{%- if page.url == '/services.html' or page.url == '/free-web-audit/' -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "{{ schema_url }}#service",
+  "name": "{{ schema_title | escape }}",
+  "url": "{{ schema_url }}",
+  "description": "{{ schema_desc | escape }}",
+  "provider": {
+    "@id": "{{ '/' | absolute_url }}#organization"
+  },
+  "areaServed": [
+    "Western Kentucky",
+    "Kentucky",
+    "United States"
+  ],
+  "serviceType": "Small business website and content support"
+}
+</script>
+{%- endif -%}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,77 @@
+# Bluedobie Developing
+
+Bluedobie Developing is a founder-led small business web design and content systems company based in Princeton, Kentucky. Founded by Melanie Brown, Bluedobie helps small businesses reduce website and content overwhelm through practical websites, light website edits, free website audits, DobieCore Suite, and future AI workflow/business continuity tools.
+
+## Primary Entity
+
+- Name: Bluedobie Developing
+- Legal name: Bluedobie Developing, LLC
+- Founder: Melanie Brown
+- Location: Princeton, Kentucky
+- Local service area: Western Kentucky
+- National availability: DobieCore Suite and content systems
+- Website: https://www.bluedobiedev.com/
+- Contact: melanie.brown@bluedobiedev.com
+- Phone: 270-388-3535
+
+## What Bluedobie Developing Does
+
+Bluedobie Developing helps small business owners who feel overwhelmed by websites, content, and practical digital systems. The business focuses on clear, sustainable tools rather than bloated tech stacks or agency-style complexity.
+
+Primary services and products include:
+
+- Basic small business websites
+- Light website edits and updates
+- Website cleanup
+- Free website audits
+- Local SEO basics
+- Content systems
+- Brand voice-based content support
+- DobieCore Suite
+- Bifrost, a future AI workflow routing and business continuity system
+
+## Key Pages
+
+- Home: https://www.bluedobiedev.com/
+- About: https://www.bluedobiedev.com/about.html
+- Services: https://www.bluedobiedev.com/services.html
+- Free Website Audit: https://www.bluedobiedev.com/free-web-audit/
+- DobieCore Suite: https://www.bluedobiedev.com/dobiecore/
+- Looking Ahead / Bifrost: https://www.bluedobiedev.com/looking-ahead/
+- Portfolio: https://www.bluedobiedev.com/our-portfolio.html
+- FAQ: https://www.bluedobiedev.com/FAQ.html
+- Contact: https://www.bluedobiedev.com/contact.html
+- Meet Sabre: https://www.bluedobiedev.com/meet-sabre.html
+- Bluedobie Dialogues on Medium: https://www.bluedobiedev.com/dialogues-medium.html
+
+## Products and Concepts
+
+### DobieCore Suite
+
+DobieCore Suite is a brand voice-based content support system for small businesses. It helps with prewriting, captions, images, blogs, and content calendar planning so business owners are not starting from a blank page every time.
+
+Canonical page: https://www.bluedobiedev.com/dobiecore/
+
+### Bifrost
+
+Bifrost is a developing local-first system for AI workflow routing and small business continuity planning. It is intended to help business owners route tasks to the right kind of support and reduce operational disruption during unexpected absence.
+
+Canonical page: https://www.bluedobiedev.com/looking-ahead/
+
+### Free Website Audit
+
+The free website audit is a plain-language review for small business websites. It looks at first impression, mobile usability, calls to action, local SEO basics, content clarity, navigation, trust signals, contact path, and basic technical issues.
+
+Canonical page: https://www.bluedobiedev.com/free-web-audit/
+
+## Important Relationships
+
+- Melanie Brown founded Bluedobie Developing.
+- Bluedobie Developing provides website services and content systems for small businesses.
+- DobieCore Suite is a Bluedobie product focused on brand voice-based content support.
+- Bifrost is a developing Bluedobie concept for AI workflow routing and business continuity.
+- Sabre is Melanie Brown's blue Doberman and part of the Bluedobie brand story.
+
+## Best Summary
+
+Bluedobie Developing is a practical, founder-led web design and content systems company for small businesses. It is based in Princeton, Kentucky, serves local website clients in Western Kentucky, and offers DobieCore Suite nationally for brand voice-based content support.


### PR DESCRIPTION
## Summary

This PR adds the first technical GEO foundation for Bluedobie Developing without changing visible page copy or touching the old blog/Medium cleanup.

### Added

- `llms.txt` with an AI-readable overview of Bluedobie Developing, Melanie Brown, DobieCore, Bifrost, services, and key pages
- Centralized JSON-LD include: `_includes/schema-jsonld.html`
- Global entity schema for:
  - Bluedobie Developing as `ProfessionalService` / `LocalBusiness`
  - Melanie Brown as `Person`
  - Sitewide `WebSite`
  - Per-page `WebPage`
  - `BreadcrumbList`
  - `FAQPage`
  - DobieCore as `WebApplication`
  - Bifrost as `CreativeWork`
  - Sabre as a brand-story entity
  - Services and Free Web Audit as `Service`
- Sitewide metadata in `_config.yml`
- Improved shared head metadata:
  - canonical fallback now supports both `canonical_url` and `canonical`
  - Open Graph site name
  - improved image fallback
- FAQ canonical metadata cleanup

### Validation notes

- Static connector-side review completed
- Schema template was hardened with Jekyll `jsonify` for dynamic JSON-LD values
- Final validation should be performed against rendered pages after GitHub Pages builds:
  - `/`
  - `/FAQ.html`
  - `/services.html`
  - `/free-web-audit/`
  - `/dobiecore/`
  - `/looking-ahead/`
  - `/meet-sabre.html`

### Not included in this PR

- Blog cleanup
- Medium widget changes
- Redirect strategy
- Visible content rewrites
- Knowledge Center / answer-surface pages

Those should stay in a later content GEO sprint.