### PR TITLE
[codex] Add Digital Foundation knowledge page

### DIFF
--- a/css/knowledge.css
+++ b/css/knowledge.css
@@ -1,0 +1,302 @@
+/* ========================================
+   KNOWLEDGE CENTER STYLES
+   Reusable article pattern for Bluedobie education pages
+   ======================================== */
+
+.knowledge-page {
+  color: var(--color-text-primary, #1f2933);
+  background: #ffffff;
+}
+
+.knowledge-container {
+  width: min(100% - 2rem, 1120px);
+  margin: 0 auto;
+}
+
+.knowledge-hero {
+  padding: clamp(4rem, 8vw, 7rem) 0 2.5rem;
+  text-align: center;
+  background:
+    radial-gradient(circle at top left, rgba(4, 45, 77, 0.10), transparent 34rem),
+    linear-gradient(180deg, #ffffff 0%, #f7f9fb 100%);
+  border-bottom: 1px solid rgba(4, 45, 77, 0.12);
+}
+
+.knowledge-hero .eyebrow {
+  margin: 0 0 1rem;
+  color: #042d4d;
+  font-size: 0.85rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.knowledge-hero h1 {
+  max-width: 920px;
+  margin: 0 auto 1.25rem;
+  font-family: var(--font-heading, "Instrument Serif", Georgia, serif);
+  color: #042d4d;
+  font-size: clamp(3rem, 8vw, 6rem);
+  font-weight: 400;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+.hero-summary {
+  max-width: 720px;
+  margin: 0 auto;
+  color: #263746;
+  font-size: clamp(1.15rem, 2.3vw, 1.45rem);
+  line-height: 1.55;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.knowledge-page .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0.9rem 1.35rem;
+  border-radius: 8px;
+  font-weight: 800;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.knowledge-page .btn:hover,
+.knowledge-page .btn:focus {
+  transform: translateY(-2px);
+}
+
+.knowledge-page .btn:focus-visible {
+  outline: 3px solid #042d4d;
+  outline-offset: 3px;
+}
+
+.knowledge-page .btn-primary {
+  background: #042d4d;
+  color: #ffffff;
+  border: 2px solid #042d4d;
+  box-shadow: 0 10px 24px rgba(4, 45, 77, 0.18);
+}
+
+.knowledge-page .btn-primary:hover,
+.knowledge-page .btn-primary:focus {
+  background: #0b3f68;
+  color: #ffffff;
+}
+
+.knowledge-page .btn-secondary {
+  background: #ffffff;
+  color: #042d4d;
+  border: 2px solid rgba(4, 45, 77, 0.35);
+}
+
+.knowledge-page .btn-secondary:hover,
+.knowledge-page .btn-secondary:focus {
+  border-color: #042d4d;
+  box-shadow: 0 8px 18px rgba(4, 45, 77, 0.12);
+}
+
+.knowledge-visual {
+  padding: 3rem 0 1rem;
+  background: #ffffff;
+}
+
+.foundation-figure {
+  margin: 0 auto;
+  max-width: 1180px;
+  text-align: center;
+}
+
+.foundation-figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 18px;
+  box-shadow: 0 22px 60px rgba(4, 45, 77, 0.16);
+  border: 1px solid rgba(4, 45, 77, 0.12);
+  background: #ffffff;
+}
+
+.foundation-figure figcaption {
+  margin-top: 1rem;
+  color: #042d4d;
+  font-family: var(--font-heading, "Instrument Serif", Georgia, serif);
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  font-style: italic;
+}
+
+.knowledge-section {
+  padding: clamp(3rem, 7vw, 5.5rem) 0;
+}
+
+.knowledge-section-alt {
+  background: #ececec;
+  border-block: 1px solid rgba(4, 45, 77, 0.10);
+}
+
+.article-body {
+  max-width: 820px;
+}
+
+.article-body .lead {
+  color: #042d4d;
+  font-size: clamp(1.25rem, 2.4vw, 1.65rem);
+  line-height: 1.55;
+  font-weight: 600;
+}
+
+.article-body p,
+.article-body li {
+  color: #2d3742;
+  font-size: 1.08rem;
+  line-height: 1.75;
+}
+
+.article-body p {
+  margin: 0 0 1.25rem;
+}
+
+.article-body h2 {
+  margin: 3.25rem 0 1rem;
+  color: #042d4d;
+  font-family: var(--font-heading, "Instrument Serif", Georgia, serif);
+  font-size: clamp(2.1rem, 4.4vw, 3.2rem);
+  font-weight: 400;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  text-align: left;
+}
+
+.article-body h2::after {
+  content: "";
+  display: block;
+  width: 4rem;
+  height: 3px;
+  margin-top: 0.8rem;
+  background: #042d4d;
+  border-radius: 999px;
+}
+
+.article-body h3 {
+  margin: 2rem 0 0.5rem;
+  color: #042d4d;
+  font-size: 1.35rem;
+  line-height: 1.3;
+}
+
+.article-body ul {
+  margin: 0 0 1.75rem;
+  padding-left: 1.4rem;
+}
+
+.article-body li {
+  margin-bottom: 0.45rem;
+}
+
+.article-body code {
+  padding: 0.1rem 0.3rem;
+  border-radius: 5px;
+  background: rgba(4, 45, 77, 0.08);
+  color: #042d4d;
+  font-size: 0.95em;
+}
+
+.article-body a {
+  color: #042d4d;
+  font-weight: 800;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.article-body a:hover,
+.article-body a:focus {
+  text-decoration-thickness: 2px;
+}
+
+.knowledge-cta {
+  padding: clamp(3rem, 7vw, 5rem) 0;
+  color: #ffffff;
+  text-align: center;
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.16), transparent 24rem),
+    linear-gradient(135deg, #042d4d 0%, #063a63 100%);
+}
+
+.knowledge-cta h2 {
+  max-width: 760px;
+  margin: 0 auto 1rem;
+  color: #ffffff;
+  font-family: var(--font-heading, "Instrument Serif", Georgia, serif);
+  font-size: clamp(2.3rem, 5vw, 4rem);
+  font-weight: 400;
+  line-height: 1.05;
+}
+
+.knowledge-cta p {
+  max-width: 680px;
+  margin: 0 auto;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 1.18rem;
+  line-height: 1.65;
+}
+
+.knowledge-cta .btn-primary {
+  background: #ffffff;
+  color: #042d4d;
+  border-color: #ffffff;
+}
+
+.knowledge-cta .btn-primary:hover,
+.knowledge-cta .btn-primary:focus {
+  background: #ececec;
+  color: #042d4d;
+}
+
+.knowledge-cta .btn-secondary {
+  color: #ffffff;
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.knowledge-cta .btn-secondary:hover,
+.knowledge-cta .btn-secondary:focus {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #ffffff;
+}
+
+@media (max-width: 760px) {
+  .knowledge-container {
+    width: min(100% - 1.25rem, 1120px);
+  }
+
+  .knowledge-hero {
+    padding-top: 3.5rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .knowledge-page .btn {
+    width: 100%;
+  }
+
+  .foundation-figure img {
+    border-radius: 12px;
+  }
+
+  .article-body p,
+  .article-body li {
+    font-size: 1rem;
+  }
+}

--- a/css/knowledge.css
+++ b/css/knowledge.css
@@ -195,11 +195,52 @@
 
 .article-body ul {
   margin: 0 0 1.75rem;
-  padding-left: 1.4rem;
+  padding: 0;
+  list-style: none;
 }
 
 .article-body li {
-  margin-bottom: 0.45rem;
+  position: relative;
+  margin-bottom: 0.65rem;
+  padding-left: 1.65rem;
+}
+
+.article-body li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.72em;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #042d4d;
+  box-shadow: 0 0 0 4px rgba(4, 45, 77, 0.10);
+}
+
+.article-body .foundation-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 1.25rem 0 2rem;
+}
+
+.article-body .foundation-list li {
+  min-height: 100%;
+  margin: 0;
+  padding: 0.95rem 1rem 0.95rem 2.65rem;
+  border: 1px solid rgba(4, 45, 77, 0.14);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  box-shadow: 0 8px 18px rgba(4, 45, 77, 0.07);
+}
+
+.article-body .foundation-list li::before {
+  left: 1rem;
+  top: 1.55rem;
+  width: 0.65rem;
+  height: 0.65rem;
+  background: #042d4d;
+  box-shadow: 0 0 0 5px rgba(4, 45, 77, 0.10);
 }
 
 .article-body code {
@@ -298,5 +339,9 @@
   .article-body p,
   .article-body li {
     font-size: 1rem;
+  }
+
+  .article-body .foundation-list {
+    grid-template-columns: 1fr;
   }
 }

--- a/knowledge/what-is-a-digital-foundation/index.html
+++ b/knowledge/what-is-a-digital-foundation/index.html
@@ -1,0 +1,269 @@
+---
+layout: default-shared
+title: What Is a Digital Foundation? | Bluedobie Developing
+description: A digital foundation is the practical online setup a small business needs beyond a basic website, including search visibility, forms, analytics, schema, and AI-ready business information.
+permalink: /knowledge/what-is-a-digital-foundation/
+og_image: /assets/images/bluedobielogo_1.webp
+extra_css:
+  - /css/knowledge.css?v=1
+no_webflow_js: true
+head_extra: |
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "@id": "https://www.bluedobiedev.com/knowledge/what-is-a-digital-foundation/#article",
+    "headline": "What Is a Digital Foundation?",
+    "description": "A practical explanation of the online foundation small businesses need beyond a basic website.",
+    "author": {
+      "@id": "https://www.bluedobiedev.com/about.html#melanie-brown"
+    },
+    "publisher": {
+      "@id": "https://www.bluedobiedev.com/#organization"
+    },
+    "mainEntityOfPage": {
+      "@id": "https://www.bluedobiedev.com/knowledge/what-is-a-digital-foundation/#webpage"
+    },
+    "inLanguage": "en-US"
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "@id": "https://www.bluedobiedev.com/knowledge/what-is-a-digital-foundation/#faq",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is a digital foundation the same as a website?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. A website is part of a digital foundation, but the foundation also includes supporting pieces like search setup, metadata, analytics, forms, business profiles, structured data, and clear service information."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Do small businesses really need structured data?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Not every small business needs complex schema, but local businesses can benefit from basic structured data that helps search engines understand the business, services, location, and website structure."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does llms.txt guarantee AI tools will mention my business?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. It does not guarantee visibility. It gives AI systems a clearer source of information about the business, which can help reduce confusion and improve machine readability."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Should a home-based business publish its street address?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Usually not unless the owner intentionally wants that address public. A service-area business can often use city, state, and service area information without exposing a private street address."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the first step?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Start with a website audit. Before adding more tools or rewriting everything, it helps to know what is already working, what is missing, and what is creating friction."
+        }
+      }
+    ]
+  }
+  </script>
+---
+
+<article class="knowledge-page">
+  <header class="knowledge-hero">
+    <div class="knowledge-container">
+      <p class="eyebrow">Bluedobie Knowledge Center</p>
+      <h1>What Is a Digital Foundation?</h1>
+      <p class="hero-summary">A website is important. But a website by itself is not the whole system.</p>
+      <div class="hero-actions">
+        <a href="/free-web-audit/" class="btn btn-primary">Request a Free Web Audit</a>
+        <a href="/services.html" class="btn btn-secondary">See Website Services</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="knowledge-section">
+    <div class="knowledge-container article-body">
+      <p class="lead">For a small business, a digital foundation is the set of practical online pieces that help people find you, understand what you do, contact you, and trust that your business is real.</p>
+
+      <p>It includes your website, but it also includes the quieter things that support it: search setup, metadata, forms, analytics, business profiles, structured data, and clear information for both humans and search engines.</p>
+
+      <p>A pretty website can still be fragile.</p>
+
+      <p>A digital foundation is what makes it useful.</p>
+
+      <h2>Why a Website Alone Is Not Enough</h2>
+      <p>A lot of small business owners think the job is done once the website is live.</p>
+      <p>That makes sense. A website is the visible part. It is the storefront window.</p>
+      <p>But the pieces behind that window matter too.</p>
+      <p>If Google does not understand your business, your website has to work harder than it should. If your contact form breaks, a potential client may simply move on. If your service area is unclear, people may not know whether to call. If your pages do not explain what you offer in plain language, both people and AI tools may describe your business poorly or skip over it entirely.</p>
+      <p>The problem is not always the website design.</p>
+      <p>Sometimes the problem is that the digital system around the website was never finished.</p>
+
+      <h2>What a Digital Foundation Includes</h2>
+      <p>A digital foundation is not one single tool. It is a practical setup that gives your business a stronger online base.</p>
+      <p>For Bluedobie Developing, that usually includes pieces like:</p>
+      <ul>
+        <li>A clear, mobile-friendly website</li>
+        <li>Search-friendly page titles and descriptions</li>
+        <li>A Google Business Profile review or setup</li>
+        <li>Google Search Console</li>
+        <li>Basic analytics</li>
+        <li>Contact forms that work and reduce spam</li>
+        <li>Clear service pages</li>
+        <li>Local business information</li>
+        <li>Structured data, also called schema</li>
+        <li>An <code>llms.txt</code> file for AI-readable business context</li>
+        <li>Basic launch testing</li>
+        <li>A follow-up check after the site has had time to settle</li>
+      </ul>
+      <p>None of these pieces need to be flashy.</p>
+      <p>They need to be dependable.</p>
+
+      <h2>The Goal Is Clarity</h2>
+      <p>A good digital foundation answers basic questions clearly:</p>
+      <ul>
+        <li>Who are you?</li>
+        <li>What do you do?</li>
+        <li>Where do you work?</li>
+        <li>Who do you help?</li>
+        <li>How should someone contact you?</li>
+        <li>What should they expect next?</li>
+      </ul>
+      <p>Those questions sound simple, but many small business websites leave at least one of them fuzzy. Sometimes the phone number is easy to miss. Sometimes the service area is buried. Sometimes the homepage says “quality service” five different ways but never clearly says what the business actually does.</p>
+      <p>Clarity is not decoration.</p>
+      <p>Clarity is infrastructure.</p>
+
+      <h2>Why This Matters More Now</h2>
+      <p>Search is changing.</p>
+      <p>People still use Google, but they also ask AI assistants, map tools, voice search, social platforms, and recommendation engines to help them make decisions. Those tools need clear information to work with.</p>
+      <p>If your business information is scattered, outdated, or vague, those systems may not understand you well.</p>
+      <p>That does not mean every small business needs to chase every new technology. Most do not.</p>
+      <p>It means your business needs a clean, consistent base that can be understood by people, search engines, and AI tools without making them dig through a junk drawer.</p>
+
+      <h2>What Structured Data Does</h2>
+      <p>Structured data is code that helps search engines understand what a page is about.</p>
+      <p>For example, it can identify:</p>
+      <ul>
+        <li>Your business name</li>
+        <li>Your location</li>
+        <li>Your service area</li>
+        <li>Your phone number</li>
+        <li>Your services</li>
+        <li>Your FAQ page</li>
+        <li>Your website structure</li>
+      </ul>
+      <p>Visitors usually do not see structured data, but search engines and other systems can read it.</p>
+      <p>Think of it as labeling the drawers in your digital filing cabinet. The cabinet may already hold the right information, but labels make it easier to find and trust.</p>
+
+      <h2>What <code>llms.txt</code> Does</h2>
+      <p>An <code>llms.txt</code> file is a plain text file that gives AI systems a clear summary of your business.</p>
+      <p>It is not a replacement for your website.</p>
+      <p>It is a helper file.</p>
+      <p>It can explain your business name, services, service area, key pages, and best summary in a format that is easy for AI tools to read. For small businesses, this is part of becoming easier to understand in a world where people increasingly ask AI tools for recommendations, explanations, and comparisons.</p>
+      <p>It does not guarantee visibility.</p>
+      <p>It improves clarity.</p>
+      <p>That is the point.</p>
+
+      <h2>A Digital Foundation Should Respect Real Business Limits</h2>
+      <p>Small businesses do not need bloated systems.</p>
+      <p>They need systems they can maintain.</p>
+      <p>A good digital foundation should not create more work than it solves. It should reduce confusion, protect important information, and make the next step easier.</p>
+      <p>That matters because most small businesses are not operating with a full marketing department. They are operating around appointments, invoices, family responsibilities, weather, staffing issues, health, repairs, customer calls, and the general chaos of real life.</p>
+      <p>A system that only works when the owner has perfect energy is not durable enough.</p>
+      <p>The foundation has to work on normal days.</p>
+      <p>And on the 50% capacity days.</p>
+
+      <h2>How Bluedobie Approaches Digital Foundations</h2>
+      <p>Bluedobie Developing builds digital foundations with practical small businesses in mind.</p>
+      <p>That means we look at the whole setup, not just the surface of the website.</p>
+      <p>We look for things like:</p>
+      <ul>
+        <li>Can people tell what you do quickly?</li>
+        <li>Is your service area clear?</li>
+        <li>Do your calls to action make sense?</li>
+        <li>Are your forms working?</li>
+        <li>Is your business information consistent?</li>
+        <li>Can Google understand the site?</li>
+        <li>Can AI tools summarize the business accurately?</li>
+        <li>Are there privacy concerns, such as a home-based business address that should not be published?</li>
+        <li>Is the setup manageable after launch?</li>
+      </ul>
+      <p>The goal is not to make the internet complicated.</p>
+      <p>The goal is to make your business easier to find, easier to understand, and easier to contact.</p>
+
+      <h2>Who Needs a Digital Foundation?</h2>
+      <p>A digital foundation is especially useful for:</p>
+      <ul>
+        <li>Local service businesses</li>
+        <li>Home-based businesses</li>
+        <li>Small businesses with outdated websites</li>
+        <li>Businesses that rely on Google searches or referrals</li>
+        <li>Businesses that have changed services, locations, or contact details</li>
+        <li>Owners who are tired of duct-taping tools together</li>
+        <li>Businesses preparing for a new website launch</li>
+        <li>Businesses that want AI tools to understand them more accurately</li>
+      </ul>
+      <p>If your website exists but feels disconnected from the rest of your business, you probably do not just need a redesign.</p>
+      <p>You may need a foundation pass.</p>
+
+      <h2>What This Is Not</h2>
+      <p>A digital foundation is not a promise of instant rankings.</p>
+      <p>It is not a trick.</p>
+      <p>It is not stuffing keywords into every corner of the page and hoping Google gets impressed.</p>
+      <p>It is not adding technology just to say you added technology.</p>
+      <p>A digital foundation is a practical cleanup and setup process. It gives your business a more reliable online base so future marketing, content, search, and AI visibility have something solid to build on.</p>
+
+      <h2>Start With a Website Audit</h2>
+      <p>The easiest way to find out where your foundation stands is with a website audit.</p>
+      <p>Bluedobie’s free website audit looks at the practical pieces first: clarity, usability, search basics, page structure, and obvious friction points.</p>
+      <p>Sometimes the fix is small.</p>
+      <p>Sometimes the site needs a deeper cleanup.</p>
+      <p>Either way, the first step is seeing what is actually there.</p>
+      <p>Not guessing.</p>
+      <p>Not panicking.</p>
+      <p>Just looking at the system clearly.</p>
+    </div>
+  </section>
+
+  <section class="knowledge-section knowledge-section-alt" aria-labelledby="digital-foundation-faq">
+    <div class="knowledge-container article-body">
+      <h2 id="digital-foundation-faq">Digital Foundation FAQ</h2>
+
+      <h3>Is a digital foundation the same as a website?</h3>
+      <p>No. A website is part of your digital foundation, but the foundation also includes supporting pieces like search setup, metadata, analytics, forms, business profiles, structured data, and clear service information.</p>
+
+      <h3>Do small businesses really need structured data?</h3>
+      <p>Not every small business needs complex schema, but local businesses can benefit from basic structured data that helps search engines understand the business, services, location, and website structure.</p>
+
+      <h3>Does <code>llms.txt</code> guarantee AI tools will mention my business?</h3>
+      <p>No. It does not guarantee visibility. It gives AI systems a clearer source of information about your business, which can help reduce confusion and improve machine readability.</p>
+
+      <h3>Should a home-based business publish its street address?</h3>
+      <p>Usually not unless the owner intentionally wants that address public. A service-area business can often use city, state, and service area information without exposing a private street address.</p>
+
+      <h3>What is the first step?</h3>
+      <p>Start with a website audit. Before adding more tools or rewriting everything, it helps to know what is already working, what is missing, and what is creating friction.</p>
+    </div>
+  </section>
+
+  <section class="knowledge-cta" aria-labelledby="digital-foundation-cta">
+    <div class="knowledge-container">
+      <h2 id="digital-foundation-cta">Start With the System You Already Have</h2>
+      <p>Request a free website audit and find out whether your website has the foundation your business needs.</p>
+      <div class="hero-actions">
+        <a href="/free-web-audit/" class="btn btn-primary">Request a Free Web Audit</a>
+        <a href="/contact.html" class="btn btn-secondary">Contact Bluedobie</a>
+      </div>
+    </div>
+  </section>
+</article>

--- a/knowledge/what-is-a-digital-foundation/index.html
+++ b/knowledge/what-is-a-digital-foundation/index.html
@@ -3,9 +3,9 @@ layout: default-shared
 title: What Is a Digital Foundation? | Bluedobie Developing
 description: A digital foundation is the practical online setup a small business needs beyond a basic website, including search visibility, forms, analytics, schema, and AI-ready business information.
 permalink: /knowledge/what-is-a-digital-foundation/
-og_image: /assets/images/bluedobielogo_1.webp
+og_image: /images/digital-foundation.webp
 extra_css:
-  - /css/knowledge.css?v=1
+  - /css/knowledge.css?v=2
 no_webflow_js: true
 head_extra: |
   <script type="application/ld+json">
@@ -15,6 +15,7 @@ head_extra: |
     "@id": "https://www.bluedobiedev.com/knowledge/what-is-a-digital-foundation/#article",
     "headline": "What Is a Digital Foundation?",
     "description": "A practical explanation of the online foundation small businesses need beyond a basic website.",
+    "image": "https://www.bluedobiedev.com/images/digital-foundation.webp",
     "author": {
       "@id": "https://www.bluedobiedev.com/about.html#melanie-brown"
     },
@@ -90,6 +91,15 @@ head_extra: |
       </div>
     </div>
   </header>
+
+  <section class="knowledge-visual" aria-label="Digital foundation illustration">
+    <div class="knowledge-container">
+      <figure class="foundation-figure">
+        <img src="/images/digital-foundation.webp" alt="Bluedobie Digital Foundation illustration showing a website as a house supported by Google Business Profile, schema, Search Console, analytics, forms, and llms.txt." loading="eager" width="1536" height="1024">
+        <figcaption>People see the house. The foundation keeps it standing.</figcaption>
+      </figure>
+    </div>
+  </section>
 
   <section class="knowledge-section">
     <div class="knowledge-container article-body">

--- a/knowledge/what-is-a-digital-foundation/index.html
+++ b/knowledge/what-is-a-digital-foundation/index.html
@@ -101,6 +101,13 @@ head_extra: |
     </div>
   </section>
 
+  <section class="knowledge-section knowledge-intro-bridge">
+    <div class="knowledge-container article-body">
+      <p class="lead">Think of your website as the house people see. The digital foundation is everything underneath that keeps it stable.</p>
+      <p>Most visitors never see those pieces, but they affect how easily customers can find you, trust you, and contact you. That is why a useful website needs more than a nice front door.</p>
+    </div>
+  </section>
+
   <section class="knowledge-section">
     <div class="knowledge-container article-body">
       <p class="lead">For a small business, a digital foundation is the set of practical online pieces that help people find you, understand what you do, contact you, and trust that your business is real.</p>
@@ -122,7 +129,7 @@ head_extra: |
       <h2>What a Digital Foundation Includes</h2>
       <p>A digital foundation is not one single tool. It is a practical setup that gives your business a stronger online base.</p>
       <p>For Bluedobie Developing, that usually includes pieces like:</p>
-      <ul>
+      <ul class="foundation-list">
         <li>A clear, mobile-friendly website</li>
         <li>Search-friendly page titles and descriptions</li>
         <li>A Google Business Profile review or setup</li>


### PR DESCRIPTION
## What changed

- Added a new Knowledge Center article at `/knowledge/what-is-a-digital-foundation/`.
- Added a reusable `css/knowledge.css` stylesheet for Knowledge Center article layouts.
- Added the `images/digital-foundation.webp` illustration to the page with accessible alt text and captioning.
- Added Article JSON-LD and visible FAQ content with matching FAQPage JSON-LD.
- Styled lists with Sabre Blue bullets and a two-column card layout for the main foundation checklist.

## Why it changed

This starts Stage 2 of GEO by creating answer-surface content that explains Bluedobie concepts in practical small-business language. The page teaches what a digital foundation is, why it matters, and how Bluedobie approaches it without turning the concept into hype.

## Review notes

- Locally previewed by Melanie with Jekyll.
- Image path expected: `/images/digital-foundation.webp`.
- Page path: `/knowledge/what-is-a-digital-foundation/`.

## Suggested follow-up

After review, link this page from a future Knowledge Center landing page and possibly from the Free Web Audit or Services page.