### PR TITLE
[codex] Add GEO guide and Knowledge Center links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,6 +17,7 @@
         <ul>
           <li><a href="{{ '/services.html' | relative_url }}">Services</a></li>
           <li><a href="{{ '/free-web-audit/' | relative_url }}">Free Web Audit</a></li>
+          <li><a href="{{ '/knowledge/' | relative_url }}">Knowledge Center</a></li>
           <li><a href="{{ '/dobiecore/' | relative_url }}">DobieCore Suite</a></li>
           <li><a href="{{ '/looking-ahead/' | relative_url }}">Looking Ahead: Bifrost</a></li>
           <li><a href="{{ '/our-portfolio.html' | relative_url }}">Work</a></li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -31,6 +31,9 @@ Adjusted per Melanie:
             <a href="/free-web-audit/" class="nav-link w-inline-block">Free Web Audit</a>
           </div>
           <div class="nav-link-holder">
+            <a href="/knowledge/" class="nav-link w-inline-block">Knowledge</a>
+          </div>
+          <div class="nav-link-holder">
             <a href="/dobiecore/" class="nav-link w-inline-block">DobieCore</a>
           </div>
           <div class="nav-link-holder">

--- a/knowledge/index.html
+++ b/knowledge/index.html
@@ -51,12 +51,12 @@ no_webflow_js: true
           <span class="card-link">Read the guide</span>
         </a>
 
-        <article class="knowledge-card knowledge-card-coming-soon" aria-label="What Is GEO coming soon">
+        <a href="/knowledge/what-is-geo/" class="knowledge-card">
           <span class="card-kicker">GEO</span>
           <h3>What Is GEO?</h3>
           <p>A plain-language explanation of generative engine optimization, AI visibility, schema, and machine-readable business information.</p>
-          <span class="card-link">Coming soon</span>
-        </article>
+          <span class="card-link">Read the guide</span>
+        </a>
 
         <article class="knowledge-card knowledge-card-coming-soon" aria-label="What Is DobieCore coming soon">
           <span class="card-kicker">DobieCore</span>

--- a/knowledge/what-is-geo/index.html
+++ b/knowledge/what-is-geo/index.html
@@ -1,0 +1,192 @@
+---
+layout: default-shared
+title: What Is GEO? | Bluedobie Developing
+description: GEO, or generative engine optimization, helps small businesses make their website and business information clearer for AI tools, search systems, and real people.
+permalink: /knowledge/what-is-geo/
+og_image: /images/digital-foundation.webp
+extra_css:
+  - /css/knowledge.css?v=3
+no_webflow_js: true
+head_extra: |
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "@id": "https://www.bluedobiedev.com/knowledge/what-is-geo/#article",
+    "headline": "What Is GEO?",
+    "description": "A practical explanation of generative engine optimization and why clear, structured business information matters for small business websites.",
+    "author": {
+      "@id": "https://www.bluedobiedev.com/about.html#melanie-brown"
+    },
+    "publisher": {
+      "@id": "https://www.bluedobiedev.com/#organization"
+    },
+    "mainEntityOfPage": {
+      "@id": "https://www.bluedobiedev.com/knowledge/what-is-geo/#webpage"
+    },
+    "inLanguage": "en-US"
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "@id": "https://www.bluedobiedev.com/knowledge/what-is-geo/#faq",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is GEO the same as SEO?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. SEO focuses on helping search engines understand and rank web pages. GEO focuses on making business information clear enough for AI-driven tools and answer systems to understand, summarize, and reference. The two often overlap."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does GEO guarantee that AI tools will recommend my business?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. GEO does not guarantee recommendations or rankings. It improves the clarity and structure of your information so people, search engines, and AI systems have better material to work with."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What does GEO include for a small business website?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "GEO may include clear service descriptions, consistent contact information, structured data, internal links, helpful educational content, an llms.txt file, and pages that answer common customer questions."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Should every small business care about GEO?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Small businesses do not need to chase every AI trend. But they should care about whether their business information is clear, consistent, and easy to understand across websites, search tools, and AI-assisted discovery."
+        }
+      }
+    ]
+  }
+  </script>
+---
+
+<article class="knowledge-page">
+  <header class="knowledge-hero">
+    <div class="knowledge-container">
+      <p class="eyebrow">Bluedobie Knowledge Center</p>
+      <h1>What Is GEO?</h1>
+      <p class="hero-summary">GEO, or generative engine optimization, is about making your business easier for AI tools, search systems, and real people to understand.</p>
+      <div class="hero-actions">
+        <a href="/free-web-audit/" class="btn btn-primary">Request a Free Web Audit</a>
+        <a href="/knowledge/" class="btn btn-secondary">Back to Knowledge Center</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="knowledge-section">
+    <div class="knowledge-container article-body">
+      <p class="lead">GEO is not a magic button, and it is not a replacement for a clear website.</p>
+      <p>GEO stands for generative engine optimization. In plain language, it means organizing your website and business information so AI-assisted tools can better understand what your business does, who it helps, where it operates, and what information can be trusted.</p>
+      <p>For a small business, that matters because people are no longer finding answers in only one place. They may use Google, maps, voice search, AI summaries, social platforms, directories, or a mix of all of them before they ever contact you.</p>
+      <p>If your information is scattered, vague, outdated, or hard to interpret, those systems have less to work with.</p>
+
+      <h2>How GEO Is Different From SEO</h2>
+      <p>SEO focuses on helping search engines find, understand, and rank web pages.</p>
+      <p>GEO focuses on helping answer systems and AI tools understand the information well enough to summarize it, compare it, or use it as part of a response.</p>
+      <p>Those two things overlap.</p>
+      <p>A clear page title helps SEO. It also helps AI tools understand the page. A well-written service page helps visitors. It also gives machines better context. Structured data helps search systems. It also gives AI-readable clues about the business.</p>
+      <p>The goal is not to choose SEO or GEO.</p>
+      <p>The goal is to make the business easier to understand everywhere it may be discovered.</p>
+
+      <h2>Why GEO Matters for Small Businesses</h2>
+      <p>Small businesses often have a practical problem: the owner understands the business better than the website does.</p>
+      <p>The site may say “quality service” or “contact us today,” but it may not clearly answer:</p>
+      <ul>
+        <li>What services are actually offered?</li>
+        <li>Who is the best fit customer?</li>
+        <li>Where does the business operate?</li>
+        <li>How should someone get started?</li>
+        <li>What makes the business trustworthy?</li>
+        <li>What common questions do customers ask before reaching out?</li>
+      </ul>
+      <p>GEO pushes the website to answer those questions clearly.</p>
+      <p>That helps AI tools, but it also helps humans. That is the part worth paying attention to.</p>
+
+      <h2>What GEO Can Include</h2>
+      <p>For a small business website, GEO is usually not one single feature. It is a set of practical improvements that work together.</p>
+      <p>That may include:</p>
+      <ul class="foundation-list">
+        <li>Clear service pages</li>
+        <li>Consistent business name, phone, and location details</li>
+        <li>Service area clarity</li>
+        <li>Structured data</li>
+        <li>Frequently asked questions</li>
+        <li>Educational answer pages</li>
+        <li>Internal links between related pages</li>
+        <li>An <code>llms.txt</code> file</li>
+        <li>Updated Google Business Profile information</li>
+        <li>Clear calls to action</li>
+      </ul>
+      <p>None of those pieces should exist just to please a machine.</p>
+      <p>They should make the business clearer.</p>
+
+      <h2>What Structured Data Does</h2>
+      <p>Structured data is code that helps search systems understand what kind of information appears on a page.</p>
+      <p>For example, it can identify a business, a service, a frequently asked question, a person, a website, or an article.</p>
+      <p>People do not usually see structured data on the page, but it supports the behind-the-scenes clarity of the site. It is one of the ways a website can say, “Here is what this page is about, and here is how it connects to the rest of the business.”</p>
+
+      <h2>What <code>llms.txt</code> Does</h2>
+      <p>An <code>llms.txt</code> file is a plain text file that gives AI tools a simple summary of important site information.</p>
+      <p>It does not force an AI system to use your business. It does not guarantee that your business will be recommended.</p>
+      <p>It is more like a neatly labeled front desk folder. It gives machines a cleaner starting point when they are trying to understand the site.</p>
+
+      <h2>GEO Should Not Turn Into Hype</h2>
+      <p>There is a danger in treating GEO like the next shiny marketing panic.</p>
+      <p>Small business owners do not need another vague promise or another tool that creates more work than it saves.</p>
+      <p>A useful GEO approach should be grounded. It should improve the website, clarify the business, and support better decisions. If it only adds clutter, it is not helping.</p>
+      <p>The test is simple: does this make the business easier to understand?</p>
+
+      <h2>How Bluedobie Approaches GEO</h2>
+      <p>Bluedobie approaches GEO as part of a larger digital foundation.</p>
+      <p>That means the work is not only about AI visibility. It is about making sure the business has clear pages, accurate information, working contact paths, useful internal links, search-ready structure, and content that answers real questions.</p>
+      <p>GEO works best when it is not treated as a separate costume thrown over a weak website.</p>
+      <p>It should be built into the structure.</p>
+
+      <h2>Where to Start</h2>
+      <p>The best starting point is not a trend list.</p>
+      <p>Start by looking at the website you already have.</p>
+      <p>Can people understand what you do? Can search systems understand it? Can AI tools identify the basic facts of the business without guessing?</p>
+      <p>If the answer is not clear, the next step is not panic.</p>
+      <p>The next step is a practical audit.</p>
+    </div>
+  </section>
+
+  <section class="knowledge-section knowledge-section-alt" aria-labelledby="geo-faq">
+    <div class="knowledge-container article-body">
+      <h2 id="geo-faq">GEO FAQ</h2>
+
+      <h3>Is GEO the same as SEO?</h3>
+      <p>No. SEO focuses on helping search engines understand and rank web pages. GEO focuses on making business information clear enough for AI-driven tools and answer systems to understand, summarize, and reference. The two often overlap.</p>
+
+      <h3>Does GEO guarantee that AI tools will recommend my business?</h3>
+      <p>No. GEO does not guarantee recommendations or rankings. It improves the clarity and structure of your information so people, search engines, and AI systems have better material to work with.</p>
+
+      <h3>What does GEO include for a small business website?</h3>
+      <p>GEO may include clear service descriptions, consistent contact information, structured data, internal links, helpful educational content, an <code>llms.txt</code> file, and pages that answer common customer questions.</p>
+
+      <h3>Should every small business care about GEO?</h3>
+      <p>Small businesses do not need to chase every AI trend. But they should care about whether their business information is clear, consistent, and easy to understand across websites, search tools, and AI-assisted discovery.</p>
+    </div>
+  </section>
+
+  <section class="knowledge-cta" aria-labelledby="geo-cta">
+    <div class="knowledge-container">
+      <h2 id="geo-cta">Make Your Business Easier to Understand</h2>
+      <p>A practical website audit can show where your current site is clear, where it is thin, and where it needs stronger structure for people, search, and AI tools.</p>
+      <div class="hero-actions">
+        <a href="/free-web-audit/" class="btn btn-primary">Request a Free Web Audit</a>
+        <a href="/knowledge/what-is-a-digital-foundation/" class="btn btn-secondary">Read About Digital Foundations</a>
+      </div>
+    </div>
+  </section>
+</article>

--- a/services.html
+++ b/services.html
@@ -71,6 +71,20 @@ permalink: /services.html
   </div>
 </section>
 
+<!-- Knowledge Center Support -->
+<section class="services-grid container" aria-labelledby="services-knowledge-heading">
+  <div class="service-card">
+    <h2 id="services-knowledge-heading">Learn Before You Decide</h2>
+    <p>Not sure what your website needs yet? The Knowledge Center explains the practical pieces behind the work in plain language.</p>
+    <ul>
+      <li><a href="/knowledge/what-is-a-digital-foundation/">What Is a Digital Foundation?</a></li>
+      <li><a href="/knowledge/what-is-a-website-audit/">What Is a Website Audit?</a></li>
+      <li><a href="/knowledge/what-is-geo/">What Is GEO?</a></li>
+    </ul>
+    <p><a href="/knowledge/">Visit the Knowledge Center →</a></p>
+  </div>
+</section>
+
 <!-- Bucket 3: Content Systems -->
 <section class="services-grid container">
   <div class="service-card">


### PR DESCRIPTION
## What changed

- Added `/knowledge/what-is-geo/`.
- Updated `/knowledge/` so the GEO card is live.
- Added Knowledge to the main navigation.
- Added Knowledge Center to the footer.
- Added a Learn Before You Decide section to `/services.html` with links to the three live guides.

## Review

Check these paths:

- `/services.html`
- `/knowledge/`
- `/knowledge/what-is-a-digital-foundation/`
- `/knowledge/what-is-a-website-audit/`
- `/knowledge/what-is-geo/`