### PR TITLE
Refresh DobieCore Suite landing page

### DIFF
--- a/DobieCoreSuite.html
+++ b/DobieCoreSuite.html
@@ -1,117 +1,189 @@
 ---
 layout: default-shared
-title: DobieCore Suite | Brand Voice-Based Content Support for Small Businesses
-description: DobieCore Suite helps small businesses create prewriting, captions, images, blogs, and content calendar templates based on their brand voice.
+title: DobieCore Suite | Content Support That Learns Your Business
+description: DobieCore Suite helps small businesses create captions, blogs, prewriting, image direction, and content plans in a consistent brand voice without starting from scratch.
 permalink: /dobiecore/
 ---
+
+{% assign app_url = "https://dobiecore-app.vercel.app?utm_source=bluedobie_website&utm_medium=cta&utm_campaign=dobiecore_page" %}
 
 <!-- Hero -->
 <section class="services-hero">
   <div class="container">
-    <header class="hero-header">
-      <h1 style="text-align: center;">DobieCore Suite</h1>
-      <p class="lead" style="text-align: center;">
-        Brand-voice based content support for small businesses that are tired
-        of starting from scratch.
+    <header class="hero-header" style="max-width: 820px; margin: 0 auto; text-align: center;">
+      <p style="font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 12px;">Content support for real small businesses</p>
+      <h1>Stop Rebuilding Your Business Context Every Time You Create Content</h1>
+      <p class="lead">
+        DobieCore Suite helps you move from a blank page to a useful draft using your Brand Voice, your ideas, and the way your business actually communicates.
       </p>
-      <p style="text-align: center; margin-top: 20px;">
-        <a href="https://dobiecore-app.vercel.app?utm_source=bluedobie_website&utm_medium=cta&utm_campaign=dobiecore_page" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Get Started Free</a>
+      <p style="margin-top: 24px;">
+        <a href="{{ app_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Start Creating Free</a>
       </p>
-      <p style="text-align: center; font-size: 0.95rem; color: rgba(255, 255, 255, 0.85);">Free to sign up. No credit card needed until you pass the free limits.</p>
+      <p style="font-size: 0.95rem; color: rgba(255, 255, 255, 0.85); margin-top: 12px;">Free to sign up. No credit card required to get started.</p>
     </header>
   </div>
 </section>
 
-<!-- What It Is -->
+<!-- Problem -->
 <section class="section">
-  <div class="container" style="max-width: 760px; margin: 0 auto;">
-    <h2>What DobieCore Suite Is</h2>
-    <p>DobieCore Suite turns your business's brand voice into reusable content support. Instead of generic AI text, you get prewriting, captions, images, blogs, and planning tools that are built around how your business actually talks.</p>
-    <p>It's not a content generator you have to babysit. It's a structured system that helps you get from "I don't know what to post" to a usable, brand-aligned draft.</p>
+  <div class="container" style="max-width: 820px; margin: 0 auto;">
+    <h2>You Should Not Have to Explain Your Business to a Blank Box Every Day</h2>
+    <p>Most content tools give you an empty field and expect you to know what to ask for. Then you repeat your tone, audience, offer, and goals every time you need a caption or blog draft.</p>
+    <p>DobieCore takes a different approach. You start by defining how your business sounds. Then you use focused tools that help you think, draft, and plan without requiring prompt-engineering expertise.</p>
   </div>
 </section>
 
-<!-- Who It's For -->
+<!-- How It Works -->
 <section class="section section-alt">
-  <div class="container" style="max-width: 760px; margin: 0 auto;">
-    <h2>Who It's For</h2>
-    <p>DobieCore Suite is built for small business owners — anywhere in the country — who struggle with:</p>
-    <ul>
-      <li>The blank page, over and over</li>
-      <li>Content that doesn't sound consistent from post to post</li>
-      <li>Keeping messaging aligned with their actual brand voice</li>
-      <li>Planning ahead instead of posting whatever comes to mind that day</li>
-    </ul>
-    <p>DobieCore Suite is available nationally. Bluedobie's local web design work stays based in Western Kentucky — DobieCore is the part of the business that goes everywhere.</p>
-  </div>
-</section>
-
-<!-- What's Included -->
-<section class="section">
   <div class="container">
-    <h2 style="text-align: center;">What's Included</h2>
-    <p class="intro-text" style="text-align: center; max-width: 700px; margin: 0 auto 32px;">Everything in DobieCore Suite is built on one foundation: your Brand Voice.</p>
-    <div class="services-grid">
+    <h2 style="text-align: center;">How DobieCore Works</h2>
+    <div class="services-grid" style="margin-top: 32px;">
       <div class="service-card">
-        <h3>Brand Voice Foundation</h3>
-        <p>Define your tone, style, and personality once. Every other tool in the suite works from this foundation.</p>
+        <h3>1. Set Your Brand Voice</h3>
+        <p>Tell DobieCore how your business should sound, including tone, personality, calls to action, and language to avoid.</p>
       </div>
       <div class="service-card">
-        <h3>Prewriting</h3>
-        <p>Structured starting points so you're never staring at an empty page.</p>
+        <h3>2. Choose What You Need</h3>
+        <p>Open a focused tool for prewriting, captions, blogs, image direction, or planning instead of wrestling with one giant prompt box.</p>
       </div>
       <div class="service-card">
-        <h3>Captions</h3>
-        <p>Platform-ready captions that stay in your brand voice, ready to use or adjust.</p>
-      </div>
-      <div class="service-card">
-        <h3>Images</h3>
-        <p>Visual direction built for consistency with your brand, not generic stock photography.</p>
-      </div>
-      <div class="service-card">
-        <h3>Blogs</h3>
-        <p>Longer-form drafts that still sound like your business, not a template.</p>
-      </div>
-      <div class="service-card">
-        <h3>Content Calendar Template</h3>
-        <p>A simple planning tool so posting becomes a routine instead of a scramble.</p>
+        <h3>3. Shape the Draft</h3>
+        <p>Use the result as a strong starting point, adjust it with your judgment, and keep moving without starting from zero.</p>
       </div>
     </div>
   </div>
 </section>
 
-<!-- Why It Helps -->
-<section class="section section-alt">
-  <div class="container" style="max-width: 760px; margin: 0 auto;">
-    <h2>Why It Helps</h2>
-    <ul>
-      <li><strong>Reduces blank-page overwhelm.</strong> You start from something, not nothing.</li>
-      <li><strong>Keeps content more consistent.</strong> Everything ties back to one brand voice.</li>
-      <li><strong>Supports planning, not full-time content creation.</strong> DobieCore helps you plan and draft — it doesn't turn you into a content creator on top of running your business.</li>
-    </ul>
-  </div>
-</section>
-
-<!-- How to Get Started -->
+<!-- Current Tools -->
 <section class="section">
-  <div class="container" style="max-width: 760px; margin: 0 auto;">
-    <h2>How to Get Started</h2>
-    <ol>
-      <li><strong>Sign up free</strong> in the DobieCore app — no credit card required.</li>
-      <li><strong>Set up your Brand Voice</strong> so prewriting, captions, images, blogs, and your content calendar all pull from the same tone and style.</li>
-      <li><strong>Start drafting and planning</strong> content on your own schedule. Upgrade only if you pass the free limits.</li>
-    </ol>
-    <p style="text-align: center; margin-top: 24px;">
-      <a href="https://dobiecore-app.vercel.app?utm_source=bluedobie_website&utm_medium=cta&utm_campaign=dobiecore_page" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Get Started Free</a>
-    </p>
+  <div class="container">
+    <h2 style="text-align: center;">Built for the Work Around the Blank Page</h2>
+    <p class="intro-text" style="text-align: center; max-width: 760px; margin: 0 auto 32px;">DobieCore is not one generator wearing six hats. Each tool supports a different part of the content process.</p>
+    <div class="services-grid">
+      <div class="service-card">
+        <h3>Brand Voice</h3>
+        <p>Create reusable voice profiles so your drafts begin closer to the way your business actually communicates.</p>
+      </div>
+      <div class="service-card">
+        <h3>Prewriting</h3>
+        <p>Work through the idea before forcing yourself to write the finished piece. Find angles, themes, headlines, and useful starting points.</p>
+      </div>
+      <div class="service-card">
+        <h3>Captions</h3>
+        <p>Create platform-ready social captions that follow your Brand Voice and give you something practical to edit or post.</p>
+      </div>
+      <div class="service-card">
+        <h3>Blog Drafts</h3>
+        <p>Turn a topic and business context into a structured long-form draft without sanding away the personality.</p>
+      </div>
+      <div class="service-card">
+        <h3>Image Direction</h3>
+        <p>Develop visual prompts and creative direction that fit the content instead of defaulting to generic stock-photo energy.</p>
+      </div>
+      <div class="service-card">
+        <h3>Content Planning</h3>
+        <p>Build a workable content rhythm so publishing becomes a repeatable process rather than a daily emergency.</p>
+      </div>
+    </div>
   </div>
 </section>
 
-<!-- CTA -->
+<!-- Vault Direction -->
+<section class="section section-alt">
+  <div class="container" style="max-width: 900px; margin: 0 auto;">
+    <h2>Growing Beyond Brand Voice: The DobieCore Business Vault</h2>
+    <p>Brand Voice is the working foundation today. DobieCore is also being expanded into a broader Business Vault designed to hold the context small-business owners repeatedly carry in their heads.</p>
+    <div class="services-grid" style="margin-top: 28px;">
+      <div class="service-card">
+        <h3>Your Business</h3>
+        <p>Business basics, positioning, goals, and the details that help content sound informed instead of generic.</p>
+      </div>
+      <div class="service-card">
+        <h3>Your Audience</h3>
+        <p>Who you help, what they struggle with, what they want, and how you want them to feel after working with you.</p>
+      </div>
+      <div class="service-card">
+        <h3>Your Offers</h3>
+        <p>Products, services, packages, and pricing context that can make future drafts more specific and useful.</p>
+      </div>
+      <div class="service-card">
+        <h3>Your Boundaries</h3>
+        <p>Content preferences, policies, FAQs, and language or marketing practices that do not belong in your business.</p>
+      </div>
+    </div>
+    <p style="margin-top: 24px;"><strong>Why this matters:</strong> the goal is not to make you fill out a giant form. It is to let DobieCore learn your business gradually, so you have less context to rebuild later.</p>
+  </div>
+</section>
+
+<!-- Difference -->
+<section class="section">
+  <div class="container" style="max-width: 900px; margin: 0 auto;">
+    <h2 style="text-align: center;">Less Prompt Engineering. More Useful Starting Points.</h2>
+    <div class="services-grid" style="margin-top: 32px;">
+      <div class="service-card">
+        <h3>Generic AI</h3>
+        <p>“Elevate your business with innovative solutions designed for today’s fast-paced world.”</p>
+        <p><strong>The problem:</strong> polished words, almost no relationship to the real business.</p>
+      </div>
+      <div class="service-card">
+        <h3>DobieCore’s Direction</h3>
+        <p>A draft shaped by your voice, your audience, your offer, and the actual point you are trying to make.</p>
+        <p><strong>The goal:</strong> useful context first, then your judgment and final edit.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Who It Is For -->
+<section class="section section-alt">
+  <div class="container" style="max-width: 820px; margin: 0 auto;">
+    <h2>Who DobieCore Is For</h2>
+    <p>DobieCore is built for small-business owners, freelancers, solo operators, and local service businesses who:</p>
+    <ul>
+      <li>Know their business but struggle to turn that knowledge into regular content</li>
+      <li>Lose time staring at blank pages or rewriting generic AI output</li>
+      <li>Want consistency without sounding stiff, automated, or over-polished</li>
+      <li>Need a system that supports their judgment instead of trying to replace it</li>
+      <li>Would rather run the business than become a full-time prompt engineer</li>
+    </ul>
+    <p>DobieCore is available nationally. Bluedobie Developing's custom web work remains rooted in Western Kentucky, while DobieCore can support businesses wherever they are.</p>
+  </div>
+</section>
+
+<!-- Pricing -->
+<section class="section">
+  <div class="container" style="max-width: 900px; margin: 0 auto;">
+    <h2 style="text-align: center;">Start Free. Upgrade When the Free Limits Become Too Small.</h2>
+    <div class="services-grid" style="margin-top: 32px;">
+      <div class="service-card">
+        <h3>Free</h3>
+        <p>Set up your Brand Voice, explore the tools, and create within the free usage limits.</p>
+        <p><strong>No credit card required to begin.</strong></p>
+      </div>
+      <div class="service-card">
+        <h3>Pro · $29/month</h3>
+        <p>For businesses that use DobieCore regularly and need higher creation limits and more room to work.</p>
+        <p><strong>Upgrade from inside the app when it makes sense.</strong></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Founder -->
+<section class="section section-alt">
+  <div class="container" style="max-width: 820px; margin: 0 auto;">
+    <h2>Built by a Small-Business Owner Who Needed the Same Thing</h2>
+    <p>DobieCore was created by Melanie Brown, founder of Bluedobie Developing. It grew from the real work of managing websites, products, client communication, and content while carrying more business context than any reasonable person should have to keep in active memory.</p>
+    <p>The product is being built around a simple standard: technology should reduce the work of running a business, not quietly hand the owner another complicated job.</p>
+  </div>
+</section>
+
+<!-- Final CTA -->
 <section class="cta-section">
-  <div class="container" style="text-align: center;">
+  <div class="container" style="text-align: center; max-width: 820px; margin: 0 auto;">
     <h2>Ready to Stop Starting From Scratch?</h2>
-    <p style="font-size: 1.2rem; margin-bottom: 30px;">Have questions before you sign up? Reach out and we'll help you get set up.</p>
-    <a href="/contact.html" class="btn btn-secondary">Work With Bluedobie</a>
+    <p style="font-size: 1.2rem; margin-bottom: 28px;">Set up your Brand Voice and start creating inside DobieCore.</p>
+    <a href="{{ app_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Start Creating Free</a>
+    <p style="margin-top: 18px;"><a href="/contact.html">Have a question first? Contact Bluedobie Developing.</a></p>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Repositions DobieCore around reducing repeated context and blank-page work
- Separates current Brand Voice and creation tools from the Business Vault direction still rolling out
- Adds a clear how-it-works flow, audience fit, pricing, founder trust, and stronger final CTA
- Keeps all primary CTAs pointed directly to the app with existing UTM tracking
- Removes the final-page detour that made Bluedobie contact the primary CTA

## Scope
- Updates only `DobieCoreSuite.html`
- No CSS, layout, or application-code changes
- Uses existing Jekyll layout and site classes

## Accuracy note
The page describes Brand Voice and the creation tools as current, while clearly labeling the broader Business Vault as an expansion in progress rather than a finished user-facing feature.