### PR TITLE
Clarify and expand the free web audit funnel

### DIFF
--- a/assets/js/formjs.js
+++ b/assets/js/formjs.js
@@ -1,27 +1,117 @@
 document.addEventListener('DOMContentLoaded', function () {
-  // Step form handlers
-  window.nextStep = function(current) {
-    document.getElementById(`step${current}`).classList.remove('active');
-    document.getElementById(`step${current + 1}`).classList.add('active');
-  };
-
-  window.prevStep = function(current) {
-    document.getElementById(`step${current}`).classList.remove('active');
-    document.getElementById(`step${current - 1}`).classList.add('active');
-  };
-
   const form = document.getElementById('multiForm');
   if (!form) return;
+
+  const steps = form.querySelectorAll('.form-step');
+  const serviceSelect = form.querySelector('select[name="request-type"]');
+  const websiteInput = form.querySelector('input[name="website"]');
+  const statusMessage = form.querySelector('#form-status');
+
+  function isAuditRequest() {
+    return serviceSelect && serviceSelect.value.toLowerCase() === 'free web audit';
+  }
+
+  function syncWebsiteRequirement() {
+    if (!websiteInput) return;
+
+    const auditSelected = isAuditRequest();
+    websiteInput.required = auditSelected;
+    websiteInput.placeholder = auditSelected
+      ? 'Website URL (required for a free web audit)'
+      : 'Website (if applicable)';
+  }
+
+  function showStep(stepNumber) {
+    steps.forEach((step) => step.classList.remove('active'));
+
+    const targetStep = form.querySelector(`#step${stepNumber}`);
+    if (targetStep) {
+      targetStep.classList.add('active');
+    }
+  }
+
+  function validateStep(stepNumber) {
+    const currentStep = form.querySelector(`#step${stepNumber}`);
+    if (!currentStep) return false;
+
+    const requiredFields = currentStep.querySelectorAll(
+      'input[required], select[required], textarea[required]'
+    );
+
+    for (const field of requiredFields) {
+      if (!field.checkValidity()) {
+        field.reportValidity();
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  window.nextStep = function (currentStep) {
+    if (!validateStep(currentStep)) return;
+
+    if (currentStep === 2 && isAuditRequest() && websiteInput && !websiteInput.checkValidity()) {
+      showStep(1);
+      websiteInput.reportValidity();
+      return;
+    }
+
+    showStep(currentStep + 1);
+  };
+
+  window.prevStep = function (targetStep) {
+    showStep(targetStep);
+  };
+
+  // Preselect a service from links such as ?service=Free%20Web%20Audit.
+  const requestedService = new URLSearchParams(window.location.search).get('service');
+
+  if (requestedService && serviceSelect) {
+    const normalizedService = requestedService.trim().toLowerCase();
+    const matchingOption = Array.from(serviceSelect.options).find(
+      (option) => option.value.trim().toLowerCase() === normalizedService
+    );
+
+    if (matchingOption) {
+      serviceSelect.value = matchingOption.value;
+    }
+  }
+
+  syncWebsiteRequirement();
+  if (serviceSelect) {
+    serviceSelect.addEventListener('change', syncWebsiteRequirement);
+  }
 
   form.addEventListener('submit', async function (event) {
     event.preventDefault();
 
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
     // Honeypot check
     const honey = form.querySelector('input[name="company_website"]');
     if (honey && honey.value.trim() !== '') {
-      console.warn("Honeypot triggered. Submission blocked.");
+      console.warn('Honeypot triggered. Submission blocked.');
       return;
     }
+
+    const submitButton = form.querySelector('button[type="submit"]');
+    const originalButtonText = submitButton ? submitButton.textContent : '';
+
+    if (statusMessage) {
+      statusMessage.textContent = '';
+      statusMessage.classList.remove('form-status-error', 'form-status-success');
+    }
+
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.textContent = 'Sending...';
+    }
+
+    form.setAttribute('aria-busy', 'true');
 
     // Collect form data
     const formData = new FormData(form);
@@ -38,15 +128,33 @@ document.addEventListener('DOMContentLoaded', function () {
       });
 
       if (!response.ok) {
-        throw new Error("Make webhook failed");
+        throw new Error(`Make webhook failed with status ${response.status}`);
       }
 
       form.reset();
-      alert("Thanks! Your message has been sent.");
+      syncWebsiteRequirement();
+      showStep(1);
 
-    } catch (err) {
-      console.error(err);
-      alert("Something went wrong. Please try again later.");
+      if (statusMessage) {
+        statusMessage.textContent = 'Thanks! Your request has been sent. We will be in touch within 24 hours.';
+        statusMessage.classList.add('form-status-success');
+      }
+    } catch (error) {
+      console.error('Form submission error:', error);
+
+      if (statusMessage) {
+        statusMessage.textContent = 'Something went wrong while sending your request. Please try again or email melanie.brown@bluedobiedev.com.';
+        statusMessage.classList.add('form-status-error');
+      } else {
+        alert('Something went wrong. Please try again later.');
+      }
+    } finally {
+      form.removeAttribute('aria-busy');
+
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.textContent = originalButtonText;
+      }
     }
   });
 });

--- a/contact.html
+++ b/contact.html
@@ -16,7 +16,8 @@ head_extra: |
     <div class="second-home-container">
       <div class="second-home-text-holder">
         <h1>Let's Work Together</h1>
-        <p class="second-home-description">Reach out about a free web audit, website help, DobieCore Suite content support, or a future Bifrost/business continuity inquiry. Book a free 30-minute consultation below and we'll talk about what you need and map out next steps.</p>
+        <p class="second-home-description">Reach out about a free web audit, website help, DobieCore Suite content support, or a future Bifrost/business continuity inquiry. If you are requesting an audit, the contact form — not the calendar — starts the process.</p>
+        <a class="button button-dark contact-hero-action" href="#custom-form-container">Start with the Contact Form</a>
       </div>
     </div>
   </div>
@@ -32,10 +33,10 @@ head_extra: |
 <div class="tidycal-embed" data-path="bluedobiedeveloping/30-minute-design"></div><script src="https://asset-tidycal.b-cdn.net/js/embed.js" async></script>
 
   <p style="margin-top: 12px;">
-  Need a follow-up or troubleshooting session? Or in case of technical difficulty.<br><strong>View all booking options :</strong>
-  <button class="btn"><a href="https://tidycal.com/bluedobiedeveloping" target="_blank" rel="noopener" style="color:#ffffff">
-    Open booking page
-  </a></button>
+  Need a follow-up or troubleshooting session, or having technical difficulty?<br><strong>View all booking options:</strong><br>
+  <a class="button" href="https://tidycal.com/bluedobiedeveloping" target="_blank" rel="noopener">
+    Open Booking Page
+  </a>
 </p>
 
 
@@ -57,11 +58,16 @@ head_extra: |
 </div>
 
 <div class="section" style="text-align: center; max-width: 800px; margin: 0 auto; padding: 60px 20px 40px;">
-  <h2>Prefer to Send a Quick Message?</h2>
-  <p style="font-size: 1.1rem; line-height: 1.7; color: var(--color-text-secondary); margin-bottom: 30px;">Can't find a time that works or just have a quick question? Fill out the form below and we'll get back to you within 24 hours. For project inquiries, booking a call gets you faster results.</p>
+  <h2>Start with the Contact Form</h2>
+  <p style="font-size: 1.1rem; line-height: 1.7; color: var(--color-text-secondary); margin-bottom: 30px;">Requesting a free web audit, have a quick question, or prefer to reach out before booking? Complete the form below and we'll get back to you within 24 hours. The consultation calendar is optional.</p>
 </div>
 
 <div class="section" id="custom-form-container">
+  <div class="audit-form-intro">
+    <p class="audit-form-label">Free Web Audit</p>
+    <h2>Request Your Free Website Audit</h2>
+    <p>Select <strong>Free Web Audit</strong> and include your website address. Submitting this form starts the audit; you do not need to schedule a consultation first.</p>
+  </div>
   <form id="multiForm" method="POST"
     class="multi-step-form">
     
@@ -71,7 +77,7 @@ head_extra: |
       <input name="first-name" placeholder="First Name" required />
       <input name="last-name" placeholder="Last Name" required />
       <input name="email" placeholder="Email" required type="email" />
-      <input name="website" placeholder="Website (if applicable)" type="url" />
+      <input aria-label="Website URL" name="website" placeholder="Website (if applicable)" type="url" />
       <button onclick="nextStep(1)" type="button">Next</button>
     </div>
 
@@ -110,9 +116,8 @@ head_extra: |
         <button type="submit">Submit</button>
       </div>
     </div>
+    <p id="form-status" class="form-status" role="status" aria-live="polite"></p>
   </form>
 </div>
 
 <script src="/assets/js/formjs.js"></script>
-
-

--- a/css/contact.css
+++ b/css/contact.css
@@ -56,6 +56,11 @@ body {
   opacity: 0.95;
 }
 
+.contact-hero-action {
+  margin-top: var(--space-lg);
+  width: auto;
+}
+
 /* ========================================
    BOOKING WIDGET
    ======================================== */
@@ -125,6 +130,53 @@ hr.dashed {
   padding: var(--space-2xl);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
+}
+
+.audit-form-intro {
+  margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-lg);
+  border-bottom: var(--border-light);
+  text-align: center;
+}
+
+.audit-form-intro h2 {
+  margin: 0 0 var(--space-sm);
+  color: var(--color-navy);
+  font-family: var(--font-heading);
+}
+
+.audit-form-intro p:last-child {
+  margin-bottom: 0;
+}
+
+.audit-form-label {
+  margin: 0 0 var(--space-xs);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.form-status {
+  min-height: 1.5em;
+  margin: var(--space-md) 0 0;
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+}
+
+.form-status-success {
+  color: #216e39;
+}
+
+.form-status-error {
+  color: #b42318;
+}
+
+.form-step button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+  transform: none;
 }
 
 /* ========================================

--- a/css/free-web-audit.css
+++ b/css/free-web-audit.css
@@ -1,0 +1,152 @@
+.audit-hero-note,
+.audit-section-heading,
+.audit-value,
+.audit-process {
+  max-width: 800px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.audit-hero-note {
+  margin-top: var(--space-md);
+  text-align: center;
+  font-weight: var(--font-weight-semibold);
+}
+
+.audit-hero-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-xl);
+}
+
+.audit-hero-actions span {
+  font-size: var(--font-size-sm);
+  opacity: 0.95;
+}
+
+.section-alt {
+  background: var(--color-background-secondary);
+}
+
+.audit-overview-grid,
+.audit-deliverables {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 1fr);
+  gap: var(--space-2xl);
+  align-items: center;
+}
+
+.audit-eyebrow {
+  margin-bottom: var(--space-xs);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.audit-figure {
+  margin: 0;
+}
+
+.audit-figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.audit-figure figcaption {
+  margin-top: var(--space-sm);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  text-align: center;
+}
+
+.audit-section-heading {
+  margin-bottom: var(--space-xl);
+  text-align: center;
+}
+
+.audit-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-lg);
+}
+
+.audit-step-card,
+.audit-callout {
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: var(--color-white);
+  box-shadow: var(--shadow-md);
+}
+
+.audit-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-bottom: var(--space-md);
+  border-radius: var(--radius-full);
+  background: var(--color-navy);
+  color: var(--color-white);
+  font-weight: var(--font-weight-semibold);
+}
+
+.audit-step-card h3,
+.audit-callout h3 {
+  margin-top: 0;
+}
+
+.audit-step-card ul {
+  padding-left: 1.25rem;
+}
+
+.audit-step-card li + li,
+.audit-process li + li {
+  margin-top: var(--space-xs);
+}
+
+.audit-callout {
+  border-left: 5px solid var(--color-navy);
+}
+
+.audit-value,
+.audit-process {
+  text-align: left;
+}
+
+.cta-section {
+  padding: var(--section-padding-md) 0;
+  background: linear-gradient(135deg, var(--color-navy) 0%, #0a2a42 100%);
+  color: var(--color-white);
+}
+
+.cta-section h2 {
+  color: var(--color-cream);
+}
+
+@media (max-width: 900px) {
+  .audit-steps {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .audit-overview-grid,
+  .audit-deliverables {
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
+
+  .audit-step-card,
+  .audit-callout {
+    padding: var(--space-lg);
+  }
+}

--- a/free-web-audit.html
+++ b/free-web-audit.html
@@ -85,18 +85,19 @@ permalink: /free-web-audit/
   <div class="container" style="max-width: 760px; margin: 0 auto;">
     <h2>What Happens After You Request It</h2>
     <ol>
-      <li><strong>You request the audit</strong> using the form or booking link below.</li>
+      <li><strong>Complete the short audit request form.</strong> Include your website address so we know which site to review.</li>
       <li><strong>We review your site</strong> against the areas above.</li>
       <li><strong>You get clear, actionable recommendations</strong> — with no obligation to book anything further.</li>
     </ol>
+    <p><strong>You do not need to schedule a consultation first.</strong> The form starts the audit process; a call can come later if it would be helpful.</p>
   </div>
 </section>
 
 <!-- CTA -->
 <section class="cta-section">
   <div class="container" style="text-align: center;">
-    <h2>Request Your Free Web Audit</h2>
-    <p style="font-size: 1.2rem; margin-bottom: 30px;">No pressure. Just a clear look at your website and what to do next.</p>
-    <a href="/contact.html" class="btn btn-primary">Request Your Free Web Audit</a>
+    <h2>Start Your Free Web Audit</h2>
+    <p style="font-size: 1.2rem; margin-bottom: 30px;">Complete the short request form and include your website address. No consultation is required to get started.</p>
+    <a href="/contact.html?service=Free%20Web%20Audit#custom-form-container" class="btn btn-primary">Start My Free Web Audit</a>
   </div>
 </section>

--- a/free-web-audit.html
+++ b/free-web-audit.html
@@ -1,8 +1,11 @@
 ---
 layout: default-shared
 title: Free Website Audit for Small Businesses | Bluedobie Developing
-description: Request a free website audit from Bluedobie Developing and receive practical recommendations for improving clarity, navigation, local SEO, and calls to action.
+description: Request a free three-part website audit with technical, search visibility, and customer-journey findings from Bluedobie Developing.
 permalink: /free-web-audit/
+image: /images/AuditBlogImage-1.webp
+extra_css:
+  - /css/free-web-audit.css
 ---
 
 <!-- Hero -->
@@ -11,85 +14,129 @@ permalink: /free-web-audit/
     <header class="hero-header">
       <h1 style="text-align: center;">Free Website Audit</h1>
       <p class="lead" style="text-align: center;">
-        A plain-language look at what's working on your website, what isn't,
-        and what to fix first — no pressure, no sales pitch.
+        Find the technical issues, search gaps, and hidden customer blockers
+        that may be quietly costing your business leads.
       </p>
+      <p class="audit-hero-note">Automated data plus a real-world review by a web developer — at no cost.</p>
+      <div class="audit-hero-actions">
+        <a href="/contact.html?service=Free%20Web%20Audit#custom-form-container" class="btn btn-primary">Start My Free Web Audit</a>
+        <span>No consultation required. The request form starts the process.</span>
+      </div>
     </header>
   </div>
 </section>
 
-<!-- Who It's For -->
-<section class="section">
-  <div class="container" style="max-width: 760px; margin: 0 auto;">
-    <h2>Who This Is For</h2>
-    <p>This audit is for small business owners who aren't sure if their website is actually helping them. Maybe it hasn't been touched in years. Maybe it looks fine but isn't bringing in leads. Maybe you just want a second opinion before spending money on a redesign.</p>
-    <p>If you're overwhelmed by your website and don't know where to start, this is the place to start.</p>
+<!-- Audit overview -->
+<section class="section audit-overview">
+  <div class="container audit-overview-grid">
+    <div>
+      <p class="audit-eyebrow">More than a score</p>
+      <h2>See Your Website Through Three Lenses</h2>
+      <p>A website can load, look polished, and still make it difficult for someone to become a customer. Our audit combines objective testing with human judgment so you can see what is working, what is getting in the way, and what deserves attention first.</p>
+      <p>It is designed for small business owners who want a useful second opinion before paying for updates or a redesign.</p>
+    </div>
+    <figure class="audit-figure">
+      <img
+        src="/images/AuditBlogImage-1.webp"
+        alt="Diagram showing how a website audit can improve conversions, website speed, and search visibility"
+        width="1536"
+        height="1024"
+        loading="lazy"
+      />
+      <figcaption>We look beyond surface-level design to find issues that affect visibility, trust, and action.</figcaption>
+    </figure>
   </div>
 </section>
 
-<!-- What the Audit Looks At -->
+<!-- Three-part audit -->
 <section class="section section-alt">
   <div class="container">
-    <h2 style="text-align: center;">What the Audit Looks At</h2>
-    <div class="services-grid">
-      <div class="service-card">
-        <h3>First Impression</h3>
-        <p>What visitors see and feel in the first few seconds on your site.</p>
-      </div>
-      <div class="service-card">
-        <h3>Mobile Usability</h3>
-        <p>How well your site works on a phone, where most visitors actually are.</p>
-      </div>
-      <div class="service-card">
-        <h3>Clear Calls to Action</h3>
-        <p>Whether visitors know what to do next — call, book, buy, or contact you.</p>
-      </div>
-      <div class="service-card">
-        <h3>Local SEO Basics</h3>
-        <p>Whether your site is set up to show up in local searches.</p>
-      </div>
-      <div class="service-card">
-        <h3>Content Clarity</h3>
-        <p>Whether your homepage actually explains what you do and who it's for.</p>
-      </div>
-      <div class="service-card">
-        <h3>Navigation</h3>
-        <p>Whether visitors can find what they need without getting lost.</p>
-      </div>
-      <div class="service-card">
-        <h3>Trust Signals</h3>
-        <p>Reviews, credentials, and details that help visitors feel confident reaching out.</p>
-      </div>
-      <div class="service-card">
-        <h3>Contact Path</h3>
-        <p>How easy it is to actually get in touch with you.</p>
-      </div>
-      <div class="service-card">
-        <h3>Basic Technical Issues</h3>
-        <p>Broken links, slow load times, and other easy-to-miss problems.</p>
-      </div>
+    <div class="audit-section-heading">
+      <p class="audit-eyebrow">How it works</p>
+      <h2>Your Three-Part Website Audit</h2>
+      <p>Each part answers a different question about how well your website supports your business.</p>
+    </div>
+    <div class="audit-steps">
+      <article class="audit-step-card">
+        <span class="audit-step-number" aria-hidden="true">1</span>
+        <h3>Technical &amp; Performance Report</h3>
+        <p>We run an automated Google PageSpeed Insights audit to measure the technical side of your site.</p>
+        <ul>
+          <li>Loading performance and Core Web Vitals</li>
+          <li>Mobile experience and best practices</li>
+          <li>Accessibility checks</li>
+          <li>Technical SEO fundamentals</li>
+        </ul>
+        <p><strong>You receive this report first as a PDF</strong>, with priority issues and practical next steps.</p>
+      </article>
+
+      <article class="audit-step-card">
+        <span class="audit-step-number" aria-hidden="true">2</span>
+        <h3>Search Visibility Review</h3>
+        <p>Using Ahrefs' free tools where appropriate, we look for signals that may affect how customers find you online.</p>
+        <ul>
+          <li>Basic site health and crawl concerns</li>
+          <li>Broken links and backlink signals</li>
+          <li>Keyword and content opportunities</li>
+          <li>Search visibility gaps worth investigating</li>
+        </ul>
+        <p>We translate useful findings into plain language instead of burying you in marketing metrics.</p>
+      </article>
+
+      <article class="audit-step-card">
+        <span class="audit-step-number" aria-hidden="true">3</span>
+        <h3>Customer Journey &amp; Conversion Review</h3>
+        <p>Then we use your website the way a real customer would and manually look for hidden blockers.</p>
+        <ul>
+          <li>Do phone and email buttons reach the right place?</li>
+          <li>Do contact forms, booking tools, social links, and calls to action work?</li>
+          <li>Can visitors quickly understand what you offer and what to do next?</li>
+          <li>Do pricing, messaging, navigation, or missing trust signals create hesitation?</li>
+        </ul>
+        <p>This is where we catch the things businesses often build once and understandably forget to retest.</p>
+      </article>
     </div>
   </div>
 </section>
 
-<!-- What You Receive -->
+<!-- Deliverables -->
 <section class="section">
-  <div class="container" style="max-width: 760px; margin: 0 auto;">
-    <h2>What You Receive</h2>
-    <p>A plain-language summary of what's working, what's not, and what to fix first — written for a business owner, not a developer. No jargon, no guilt trip about your current site.</p>
+  <div class="container audit-deliverables">
+    <div>
+      <p class="audit-eyebrow">What you receive</p>
+      <h2>Two Reports, One Clear Roadmap</h2>
+      <p><strong>First:</strong> your automated PageSpeed Insights PDF, covering measurable technical and performance findings.</p>
+      <p><strong>Then:</strong> a follow-up manual and visual report with relevant search findings, customer-journey observations, hidden blockers, and prioritized recommendations.</p>
+    </div>
+    <aside class="audit-callout">
+      <h3>Built for decisions, not jargon</h3>
+      <p>You will know what is working, what needs attention, and what to tackle first. You can use the roadmap yourself, share it with your current developer, or ask us to help implement it.</p>
+    </aside>
   </div>
 </section>
 
-<!-- What Happens After -->
+<!-- Value -->
 <section class="section section-alt">
-  <div class="container" style="max-width: 760px; margin: 0 auto;">
+  <div class="container audit-value">
+    <p class="audit-eyebrow">Why it is free</p>
+    <h2>Professional Insight Without the Upfront Cost</h2>
+    <p>Comparable professional audits that combine technical testing, search review, and hands-on customer-journey analysis often cost hundreds to the low thousands of dollars, depending on the size and depth of the site.</p>
+    <p>Bluedobie offers this audit at no cost because we would rather demonstrate the full value of our work before asking you to hire us. By the time you receive your reports, we are already familiar with your website and you have a useful roadmap — reducing friction if you decide you want help with the fixes.</p>
+    <p>There is no obligation. If you make the improvements yourself or share the findings with another developer, the audit has still done its job.</p>
+  </div>
+</section>
+
+<!-- Process -->
+<section class="section">
+  <div class="container audit-process">
     <h2>What Happens After You Request It</h2>
     <ol>
-      <li><strong>Complete the short audit request form.</strong> Include your website address so we know which site to review.</li>
-      <li><strong>We review your site</strong> against the areas above.</li>
-      <li><strong>You get clear, actionable recommendations</strong> — with no obligation to book anything further.</li>
+      <li><strong>Complete the short audit request form.</strong> Include your website address and anything you are concerned about.</li>
+      <li><strong>Receive your automated technical PDF.</strong> We run PageSpeed Insights and send the first report when it is ready.</li>
+      <li><strong>We complete the search and real-world review.</strong> We inspect visibility signals, test the customer journey, and look for conversion blockers.</li>
+      <li><strong>Receive your follow-up report.</strong> It includes the manual and visual findings plus clear, prioritized recommendations.</li>
     </ol>
-    <p><strong>You do not need to schedule a consultation first.</strong> The form starts the audit process; a call can come later if it would be helpful.</p>
+    <p><strong>You do not need to schedule a consultation first.</strong> The form starts the audit process; a call is optional later if it would be helpful.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary

- expands the Free Website Audit page into a clear three-part offer covering PageSpeed Insights, Ahrefs-based search visibility checks, and a hands-on customer-journey/conversion review
- explains the two-report delivery sequence, typical market value, and why Bluedobie provides the audit at no cost
- uses an existing audit illustration and adds responsive page-specific styling
- sends audit CTAs directly to the contact form and makes it clear that no consultation is required
- updates the contact page so the form is the audit starting point while preserving every existing service option
- preselects the requested service from the URL, requires the website URL for audit requests, validates each form step, fixes Back navigation, and improves submission feedback
- replaces invalid nested booking button/link markup

## Why

The audit page previously pointed visitors toward a general contact experience where booking a consultation could look like the primary next step, even though the form is what supplies the information needed to begin the audit.

## Test notes

- `node --check assets/js/formjs.js`
- form behavior test using a DOM environment: service preselection, conditional website requirement, step validation, and Back navigation
- structural HTML validation for both edited pages, accounting for the repository's existing inline-style and void-element conventions
- `git diff --check`
- attempted a local Jekyll build; it is blocked by the local Ruby 4/Bundler environment not exposing the `csv` standard gem to the locked Jekyll version
